### PR TITLE
Use only one string parameter in exception for KTHROW

### DIFF
--- a/include/kamping/kassert.hpp
+++ b/include/kamping/kassert.hpp
@@ -133,7 +133,7 @@
     #define KAMPING_KASSERT_HPP_KTHROW_IMPL(expression, message, assertion_type)                                    \
         do {                                                                                                        \
             if (!(expression)) {                                                                                    \
-                throw assertion_type(kamping::internal::_build_what(                                                \
+                throw assertion_type(kamping::internal::build_what(                                                 \
                     #expression, KAMPING_KASSERT_HPP_SOURCE_LOCATION,                                               \
                     (kamping::internal::RrefOStringstreamLogger{std::ostringstream{}} << message).stream().str())); \
             }                                                                                                       \
@@ -181,8 +181,8 @@ struct SourceLocation {
 /// @param where Source code location where the exception was thrown.
 /// @param message User message describing this exception.
 /// @return The description of this exception.
-[[maybe_unused]] static std::string
-_build_what(std::string const& expression, internal::SourceLocation where, std::string const& message) {
+[[maybe_unused]] std::string
+build_what(std::string const& expression, SourceLocation const where, std::string const& message) {
     using namespace std::string_literals;
     return "\n"s + where.file + ": In function '" + where.function + "':\n" + where.file + ": "
            + std::to_string(where.row) + ": FAILED ASSERTION\n" + "\t" + expression + "\n" + message + "\n";


### PR DESCRIPTION
Fixes #123 