### PR TITLE
Make CRTPHelper functions private

### DIFF
--- a/include/kamping/mpi_function_wrapper_helpers.hpp
+++ b/include/kamping/mpi_function_wrapper_helpers.hpp
@@ -142,8 +142,8 @@ private:
 /// BaseClass.
 template <typename BaseClass, template <typename> class MixinClass>
 struct CRTPHelper {
-    friend MixinClass<BaseClass>; // this allows only the class inheriting from \c CRTPHelper to access the members.
 private:
+    friend MixinClass<BaseClass>; // this allows only the class inheriting from \c CRTPHelper to access the members.
     /// @return Reference to the underlying base class.
     BaseClass& underlying() {
         return static_cast<BaseClass&>(*this);


### PR DESCRIPTION
This way they also don't show up as public functions in the documentation. 