### PR TITLE
Move -Wno-gnu-zero-variadic-macro-arguments to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     "-Wnull-dereference"
     "-Wpedantic"
     "-Wextra-semi"
+    "-Wno-gnu-zero-variadic-macro-arguments"
   )
 endif()
 

--- a/include/kamping/kassert.hpp
+++ b/include/kamping/kassert.hpp
@@ -30,13 +30,6 @@
     #define KAMPING_ASSERTION_LEVEL 3
 #endif
 
-// We use the zero variadic macro argument extension, which is supported by every major C++ compiler
-// Disable warning for macro declarations in this file
-#if defined(__clang__)
-    #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
-#endif
-
 /// @brief Assertion macro for the KaMPI.ng library. Accepts between one and three parameters.
 ///
 /// Assertions are enabled or disabled by setting a compile-time assertion level (`-DKAMPING_ASSERTION_LEVEL=<int>`).
@@ -193,11 +186,6 @@
 // THROWING_KASSERT() chooses the right implementation depending on its number of arguments.
 #define THROWING_KASSERT_2(expression, message) KAMPING_KASSERT_HPP_THROWING_KASSERT_IMPL(expression, message)
 #define THROWING_KASSERT_1(expression)          THROWING_KASSERT_2(expression, "")
-
-// Re-enable Clang warning for GNU extension
-#if defined(__clang__)
-    #pragma clang diagnostic pop
-#endif
 
 // __PRETTY_FUNCTION__ is a compiler extension supported by GCC and clang that prints more information than __func__
 #if defined(__GNUC__) || defined(__clang__)


### PR DESCRIPTION
In preparation of #184. 

---

Context: we use a technique that allows macros to take between 0/1 and n arguments (for instance, `KASSERT` can take either 1, 2 or 3 arguments). This technique is easy to implement if the number of arguments ranges between 1 and n; but if the macro should also be invocable with zero arguments, it gets really tricky with standard C++ 17. 

To solve this problem, GCC implements a language extension `, ##__VA_ARGS__`. This extension is also available in clang, icc and icx. However, clang issues a warning when using it; this PR disables that warning. 

I think it is safe to use non-standard C++ here, because (a) all compilers supported by KaMPI.ng support the extension, and (b) the extension becomes obsolete with C++ 20's `__VA_OPT__(,)` anyways. 

We already used this extension for `KASSERT`, but there it was sufficient to disable the warning locally in `kassert.hpp`. This will no longer be the case in #184, thus this PR. 

---

A bit more context on where we use this extension: suppose that we want to implement a macro `X`, that can take between 0 and 2 arguments, i.e., `X()`, `X(a)` and `X(a, b)` should all be valid invocations of the macro. To do so, we define a separate macro for each possible number of arguments: 

```
#define X0 [...]
#define X1(a) [...]
#define X2(a, b) [...]
```

Now, we need a "dispatch" macro `X` that can take 0, 1 or 2 arguments and resolve to `X0`, `X1` or `X2`. While we can't make the macro to take between 0 and 2 arguments, we can define it as a variadic macro:

```
#define X(...) [... magic that expands to X2, X1 or X0 depending on the number of arguments passed to X ...]
```

To implement this macro, we first need a helper: 

```
#define DISPATCH(x2, x1, x, ...) x
```

`DISPATCH` takes at least 3 arguments and substitutes to whatever we pass as 3rd argument, e.g.: 

```
DISPATCH(a, b, c, d, e, f) // becomes c
DISPATCH(0, 1, X2(0, 1), X1(0, 1), X0) // becomes X2(0, 1)
DISPATCH(0, X2(0), X1(0), X0) // becomes X1(0)
DISPATCH(X2(), X1(), X0) // becomes X0
```

We can use that to implement `X`: 

```
#define X(...) DISPATCH(__VA_ARGS__, X2(__VA_ARGS__), X1(__VA_ARGS__), X0)
```

`__VA_ARGS__` expands to whatever arguments we pass to `X`. Thus, if we pass 2 arguments to `X`, it also expands to two arguments. If we pass 1 argument to `X`, it expands to 1 argument. Thus, we can "move" the correct implementation for `X` to be the 3rd argument passed to `DISPATCH`:

* `X(0, 1)` becomes `DISPATCH(0, 1, X2(0, 1), X1(0, 1), X0)` becomes `X2(0, 1)` -- nice

* `X(0)` becomes `DISPATCH(0, X2(0), X1(0), X0)` becomes `X1(0)` -- nice

* `X()` becomes `DISPATCH(, X2(), X1(), X0)` becomes `X1()` -- wait, what? 

Unfortunately, we still have the `,` token after the first `__VA_ARGS__` in the definition of `X`. Since the preprocessor is perfectly fine with empty arguments, this counts as the first argument passed to `DISPATCH`. 

That's where the GNU extension comes into play. With GCC (and all other compilers that we support), we can write: 

```
#define X(...) DISPATCH(, ##__VA_ARGS__, X2(__VA_ARGS__), X1(__VA_ARGS__), X0)
```

The semantic of `, ##__VA_ARGS__` is as follows: 

* If `__VA_ARGS__` expands to a non-empty token sequence, this is `, [tokens]` (as expected) 

* If `__VA_ARGS__` expands to an empty token sequence, it swallows the preceding comma and expands to thin air

Thus, we get new substitutions for `X`: 

* `X(0, 1)` becomes `DISPATCH(, 0, 1, X2(0, 1), X1(0, 1), X0)`

* `X(0)` becomes `DISPATCH(, 0, X2(0), X1(0), X0)`

* `X()` becomes `DISPATCH(, X2(), X1(), X0)`  -- note that the comma preceding the `__VA_ARGS__` expansion vanished  

Thus, the 4th argument of `DISPATCH` is always the correct implementation; thus, we can alter the definition of `DISPATCH` to return its 4th parameter:

```
#define DISPATCH(dummy, x2, x1, x, ...) x
```

And we are done. 

---

Once we switch to C++ 20, we can replace the definition with 

```
#define X(...) DISPATCH(__VA_OPT__(,) __VA_ARGS__, X2(__VA_ARGS__), X1(__VA_ARGS__), X0)
```

`__VA_OPT__(x)` expands to `x` iff. `__VA_ARGS__` expands to a non-empty token sequence. 