### PR TITLE
Add recv_count[_out]() parameter object / factory 

### DIFF
--- a/include/kamping/parameter_factories.hpp
+++ b/include/kamping/parameter_factories.hpp
@@ -57,7 +57,6 @@ auto send_buf(internal::ignore_t<Data> ignore [[maybe_unused]]) {
     return internal::EmptyBuffer<Data, internal::ParameterType::send_buf>();
 }
 
-
 /// @brief Generates buffer wrapper based on the data in the send buffer, i.e. the underlying storage must contain
 /// the data element(s) to send.
 ///
@@ -101,6 +100,20 @@ auto send_counts(const Container& container) {
 template <typename Container>
 auto recv_counts(const Container& container) {
     return internal::ContainerBasedConstBuffer<Container, internal::ParameterType::recv_counts>(container);
+}
+
+/// @brief Generates a wrapper for a recv count input parameter.
+/// @param recv_count The recv count to be encapsulated.
+/// @return Wrapper around the given recv count.
+inline auto recv_count(int const recv_count) {
+    return internal::RecvCount<int const>(recv_count);
+}
+
+/// @brief Generates a wrapper for a recv count output parameter.
+/// @param recv_count_out Reference for the output parameter.
+/// @return Wrapper around the given reference.
+inline auto recv_count_out(int& recv_count_out) {
+    return internal::RecvCount<int&>(recv_count_out);
 }
 
 /// @brief Generates buffer wrapper based on a container for the send displacements, i.e. the underlying storage must

--- a/include/kamping/parameter_type_definitions.hpp
+++ b/include/kamping/parameter_type_definitions.hpp
@@ -40,6 +40,8 @@ enum class ParameterType {
                  ///< the involved PEs.
     recv_displs, ///< Tag used to represent a receive displacements buffer, i.e. a buffer containing the receive
                  ///< displacements from the involved PEs.
+    recv_count,  ///< Tag used to represent the receive count of a collective operation where only data
+                 ///< from one PE is received.
     send_counts, ///< Tag used to represent a send counts buffer, i.e. a buffer containing the send counts from the
                  ///< involved PEs.
     send_displs, ///< Tag used to represent a send displacements buffer, i.e. a buffer containing the send displacements

--- a/tests/parameter_factories_test.cpp
+++ b/tests/parameter_factories_test.cpp
@@ -304,3 +304,18 @@ TEST(ParameterFactoriesTest, root_basics) {
     auto root_obj = root(22);
     EXPECT_EQ(root_obj.rank(), 22);
 }
+
+TEST(ParameterFactoriesTest, recv_count_in_basics) {
+    auto recv_count_in_obj = recv_count(42);
+    EXPECT_EQ(recv_count_in_obj.recv_count(), 42);
+    EXPECT_FALSE(decltype(recv_count_in_obj)::is_modifiable);
+}
+
+TEST(ParameterFactoriesTest, recv_count_out_basics) {
+    int  recv_count;
+    auto recv_count_out_obj = recv_count_out(recv_count);
+    recv_count_out_obj.set_recv_count(42);
+    EXPECT_EQ(recv_count_out_obj.recv_count(), 42);
+    EXPECT_EQ(recv_count, 42);
+    EXPECT_TRUE(decltype(recv_count_out_obj)::is_modifiable);
+}


### PR DESCRIPTION
Extracted from #170, adds `recv_count(x)` and `recv_count_out(x)`. 