### PR TITLE
Only bump submodules once a month

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,6 @@ updates:
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     labels:
       - "review"


### PR DESCRIPTION
I think that daily bumps are way to frequent, especially because we don't really need the most recent versions of the submodules that we currently include. 

Once we include our own secondary projects as submodules, those should be bump'd more frequently. 

Opinions? 