### PR TITLE
Improvements to scripts/run_clang_format.sh

### DIFF
--- a/scripts/run_clang_format.sh
+++ b/scripts/run_clang_format.sh
@@ -1,10 +1,13 @@
-#!/bin/sh 
+#!/bin/bash
 
 if [[ "$PWD" == */scripts ]]; then
-	echo "Script must be run from the project's root directory"
-	exit 1
+    echo "Script must be run from the project's root directory."
+    exit 1
 fi
 
-for directory in "include" "tests" "examples"; do 
-	find $directory -type f \( -name "*.cpp" -o -name "*.hpp" \) -exec clang-format -i {} \;
+for directory in "include" "tests" "examples"; do
+    find "$directory"                           \
+        -type f                                 \
+        \( -name "*.cpp" -or -name "*.hpp" \)   \
+        -exec clang-format -i {} \;
 done


### PR DESCRIPTION
* Change shebang to bash to support `[[` and `]]`.
* Replace indentation with `\t` by spaces.
* Add missing '.' at the end of a sentence.
* Expand a short option.
* Break up the `find` command for better readability.
* Add a missing quotation.