### PR TITLE
Fix bug in rank_shifted_cyclic with negative wraparound

### DIFF
--- a/include/kamping/communicator.hpp
+++ b/include/kamping/communicator.hpp
@@ -149,7 +149,8 @@ public:
     /// @param distance Distance of the new rank to the rank of this MPI thread.
     /// @return The circular rank that is \c distance ranks apart from this MPI threads rank.
     [[nodiscard]] int rank_shifted_cyclic(int const distance) const {
-        return (_rank + distance) % _size;
+        const int capped_distance = distance % _size;
+        return (_rank + capped_distance + _size) % _size;
     }
 
     /// @brief Checks if a rank is a valid rank for this communicator, i.e., if the rank is in [0, size).

--- a/tests/mpi_communicator_test.cpp
+++ b/tests/mpi_communicator_test.cpp
@@ -118,7 +118,7 @@ TEST_F(CommunicatorTest, rank_shifted_cyclic) {
     Communicator comm;
 
     for (int i = -(2 * size); i < (2 * size); ++i) {
-        EXPECT_EQ((rank + i) % size, comm.rank_shifted_cyclic(i));
+        EXPECT_EQ((rank + i + 2 * size) % size, comm.rank_shifted_cyclic(i));
     }
 }
 


### PR DESCRIPTION
Classic bug caused by C++'s handling of modulo with negative numbers ;)