### PR TITLE
Make bcast_value generic in scatter

### DIFF
--- a/include/kamping/collectives/scatter.hpp
+++ b/include/kamping/collectives/scatter.hpp
@@ -153,7 +153,7 @@ protected:
     Scatter() = default;
 
 private:
-    // Broadcasts a value from on PE to all PEs.
+    // Broadcasts a value from one PE to all PEs.
     template <typename T>
     int bcast_value(T const bcast_value, int const root) {
         T                          bcast_result = bcast_value;


### PR DESCRIPTION
Sometimes `bool`s are passed to it instead of `int`.

For some reason that doesn't cause a warning but it makes me uncomfortable ;)