### PR TITLE
Add new target to run tests in parallel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,19 +72,14 @@ jobs:
       run: mpirun --version
     - name: print-mpicxx-flags
       run: mpicxx -show
-    - name: cpu-cores
-      uses: SimenB/github-actions-cpu-cores@v1
-      id: cpu-cores
-    - name: print-cpu-cores
-      run: echo ${{ steps.cpu-cores.outputs.count }}
     - name: cmake
       run: cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.build-mode }} -DCMAKE_CXX_COMPILER=${{ matrix.compiler.cxx }} -DCMAKE_C_COMPILER=${{ matrix.compiler.cc }} -DKAMPING_WARNINGS_ARE_ERRORS=ON -DKAMPING_EXCEPTION_MODE=${{ matrix.exception-mode }} -DKAMPING_ASSERTION_LEVEL=${{ matrix.assertion-level }} -DKAMPING_TESTS_DISCOVER=OFF
     - name: build
-      run: cmake --build build/ --parallel ${{ steps.cpu-cores.outputs.count }}
+      run: cmake --build build/ --parallel
     - name: Allow-running-mpi
       run: |
         echo OMPI_ALLOW_RUN_AS_ROOT=1 >> $GITHUB_ENV
         echo OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1 >> $GITHUB_ENV
     - name: run tests
       if: matrix.run-tests == 'ON'
-      run: ctest --output-on-failure --parallel ${{ steps.cpu-cores.outputs.count }} --test-dir build/
+      run: make -C build/ check

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,12 @@ include(KaTestrophe)
 include(KampingTestHelper)
 include(GoogleTest)
 
+include(ProcessorCount)
+ProcessorCount(N)
+if(NOT N EQUAL 0)
+  add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -j ${N})
+endif()
+
 # Registering tests without MPI:
 kamping_register_test(test_checking_casts FILES checking_casts_test.cpp)
 kamping_register_test(test_kassert_assertion_mode NO_EXCEPTION_MODE FILES kassert_test.cpp)


### PR DESCRIPTION
This just makes it easier to run tests in parallel

Also removes the need for the cpu-cores github action

Part of #189 