### PR TITLE
Just test that comm.barrier calls MPI_Barrier

### DIFF
--- a/tests/collectives/mpi_barrier_test.cpp
+++ b/tests/collectives/mpi_barrier_test.cpp
@@ -25,7 +25,7 @@ TEST(BarrierTest, barrier) {
     Communicator comm;
 
     // One rank calls MPI_Barrier directly, all others call comm.barrier.
-    // If comm.barrier correctly calls MPI_Barrier this finishes. Otherwise it deadlocks on at least one rank.
+    // If comm.barrier() correctly calls MPI_Barrier, this finishes. Otherwise it deadlocks on at least one rank.
 
     // Use rank 1 as the rank that calls MPI_Barrier directly so when running on 1 rank, we test that comm.barrier()
     // finishes correctly.


### PR DESCRIPTION
Fixes #274 

MPI Implementations themselves don't seem to have a test for barrier so there doesn't seem to be a good way of testing for correctnes. This at least tests that MPI_Barrier is called.