### PR TITLE
Hide missing doxygen warning if project is not the root project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,9 +23,9 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
       WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
       COMMENT "Generating Documentation"
       VERBATIM)
+  else()
+    message(STATUS "Doxygen not found, not building docs")
   endif()
-else()
-  message(STATUS "Doxygen not found, not building docs")
 endif()
 
 # Require out-of-source builds


### PR DESCRIPTION
Same as https://github.com/kamping-site/kassert/pull/15