### PR TITLE
Disable extract() with enable_if

### DIFF
--- a/include/kamping/parameter_objects.hpp
+++ b/include/kamping/parameter_objects.hpp
@@ -265,11 +265,8 @@ public:
     /// state.
     ///
     /// @return Moves the underlying container out of the DataBuffer.
+    template <bool enabled = allocation == BufferAllocation::lib_allocated, std::enable_if_t<enabled, bool> = true>
     MemberTypeWithConst extract() {
-        // This works because in template classes, only functions that are actually called are instantiated
-        static_assert(
-            allocation == BufferAllocation::lib_allocated,
-            "extract() must only be called on library allocated DataBuffers");
         static_assert(
             ownership == BufferOwnership::owning, "Moving out of a reference should not be done because it would leave "
                                                   "a users container in an unspecified state.");

--- a/tests/parameter_objects_test.cpp
+++ b/tests/parameter_objects_test.cpp
@@ -461,6 +461,19 @@ TEST(UserAllocatedContainerBasedBufferTest, resize_user_allocated_buffer) {
     }
 }
 
+TEST(DataBufferTest, has_extract) {
+    static_assert(
+        has_extract_v<DataBuffer<
+            int, ParameterType::send_buf, BufferModifiability::modifiable, BufferOwnership::owning,
+            BufferAllocation::lib_allocated> >,
+        "Library allocated DataBuffers must have an extract() member function");
+    static_assert(
+        !has_extract_v<DataBuffer<
+            int, ParameterType::send_buf, BufferModifiability::modifiable, BufferOwnership::owning,
+            BufferAllocation::user_allocated> >,
+        "User allocated DataBuffers must not have an extract() member function");
+}
+
 #if KASSERT_ENABLED(KAMPING_ASSERTION_LEVEL_NORMAL)
 TEST(LibAllocatedContainerBasedBufferTest, prevent_usage_after_extraction) {
     LibAllocatedContainerBasedBuffer<std::vector<int>, ParameterType::recv_buf> buffer;


### PR DESCRIPTION
Because MPIResult uses that information to determine if a buffer is lib allocated