### PR TITLE
Add Communicator::bcast_single(...)

### DIFF
--- a/include/kamping/collectives/bcast.hpp
+++ b/include/kamping/collectives/bcast.hpp
@@ -127,3 +127,8 @@ auto kamping::Communicator::bcast(Args... args) const {
         std::move(send_recv_buf), BufferCategoryNotUsed{}, std::move(recv_count_param), BufferCategoryNotUsed{},
         BufferCategoryNotUsed{});
 } // namespace kamping::internal
+
+// template <typename... Args>
+// auto kamping::Communicator::bcast_single(Args... args) const {
+//     
+// }


### PR DESCRIPTION
`bcast` uses a `send_recv_buf`, which does not fit naturally onto the `_single` interface we had in mind – provide the send buffer as an argument, return the received value. 

We could implement the following interface for `bcast_single`:

```cpp
// On the root rank
int value = 1;
comm.bcast_single(send_buf(value));
// and once we have the send_buf as a first parameter
comm.bcast_single(value)

// on all other ranks
int value = comm.bcast_single();

// What's currently implemented is the following:
int value = /* ... */;
comm.bcast(send_recv_buf(value));
// which will become the following, once we have the send_recv_buf as the first argument:
comm.bcast(value);
// which is the interface I would feel most comfortable with and which is closest to MPI
```

This raises the question if we even want a `bcast_single`? What do you think?