### PR TITLE
Give C++ and CMake Formatting checks unique names

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -9,7 +9,7 @@ on:
       - main
   workflow_dispatch:
 jobs:
-  formatting-check:
+  cpp-formatting-check:
     name: C++ Formatting Check
     runs-on: self-hosted
     container:

--- a/.github/workflows/cmake-format-check.yml
+++ b/.github/workflows/cmake-format-check.yml
@@ -9,7 +9,7 @@ on:
       - main
   workflow_dispatch:
 jobs:
-  formatting-check:
+  cmake-formatting-check:
     name: CMake Formatting Check
     runs-on: self-hosted
     container:


### PR DESCRIPTION
Branch protection rules apparently use these names, so they should be unique in order to be selectable.