### PR TITLE
Automatically add or remove empty lines around access modifiers

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -72,3 +72,5 @@ SpacesInSquareBrackets: 'false'
 Standard: Auto
 TabWidth: '4'
 UseTab: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+EmptyLineAfterAccessModifier: Never


### PR DESCRIPTION
Apparently we already do this everywhere, so this just makes sure of it.