### PR TITLE
Use different directories in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,14 @@
 version: 2
 updates:
   - package-ecosystem: "gitsubmodule"
-    directory: "/"
+    directory: "extern/googletest"
     schedule:
       interval: "monthly"
+    labels:
+      - "review"
+  - package-ecosystem: "gitsubmodule"
+    directory: "extern/kassert"
+    schedule:
+      interval: "daily"
     labels:
       - "review"


### PR DESCRIPTION
I'm hoping this might ignore the doxygen css dependency and allows us to use different update interval for our submodules