### PR TITLE
Fixed googletest discovery script

### DIFF
--- a/tests/cmake/MPIGoogleTest.cmake
+++ b/tests/cmake/MPIGoogleTest.cmake
@@ -1,6 +1,6 @@
 # Adapted by the KaMPIng authors from GoogleTest.cmake included in CMake.
 #
-# Original license information: Distributed under the OSI-approved BSD 3-Clause License.See accompanying file
+# Original license information: Distributed under the OSI-approved BSD 3-Clause License. See accompanying file
 # Copyright.txt or https://cmake.org/licensing for details.
 
 function (katestrophe_discover_tests TARGET)


### PR DESCRIPTION
This just includes the fix from CMake's upstream implementation.