### PR TITLE
Fix recv_counts() parameter for scatter and bcast.

### DIFF
--- a/include/kamping/collectives/bcast.hpp
+++ b/include/kamping/collectives/bcast.hpp
@@ -13,6 +13,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include <kassert/kassert.hpp>
 #include <mpi.h>
 
@@ -95,6 +97,10 @@ auto kamping::Communicator::bcast(Args... args) const {
     );
 
     // If it is not user provided, broadcast the size of send_recv_buf from the root to all ranks.
+    static_assert(
+        std::remove_reference_t<decltype(recv_count_param)>::is_single_element,
+        "recv_counts() parameter must be a single value."
+    );
     int recv_count = recv_count_param.get_single_element();
     if constexpr (recv_count_is_output_parameter) {
         if (this->is_root(root.rank())) {

--- a/include/kamping/collectives/scatter.hpp
+++ b/include/kamping/collectives/scatter.hpp
@@ -138,11 +138,15 @@ auto kamping::Communicator::scatter(Args... args) const {
     );
 
     // If it is an output parameter, broadcast send_count to get recv_count
+    static_assert(
+        std::remove_reference_t<decltype(recv_count_param)>::is_single_element,
+        "recv_counts() parameter must be a single value."
+    );
     if constexpr (is_output_parameter) {
-        *recv_count_param.get().data() = bcast_value(*this, send_count, int_root);
+        recv_count_param.underlying() = bcast_value(*this, send_count, int_root);
     }
 
-    int recv_count = *recv_count_param.get().data();
+    int recv_count = recv_count_param.get_single_element();
 
     // Validate against send_count
     KASSERT(


### PR DESCRIPTION
This parameter only expects a single integer value. While providing more than one value fails to compile for bcast, it did not for scatter, where it silently took the first value.

This introduces an additional check and a more useful error message.