### PR TITLE
Use checkout action v3 in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
             run-tests: OFF
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: 'recursive'
     - name: export-compiler

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -13,7 +13,7 @@ jobs:
     container:
       image: "localhost:5000/kamping-ci"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Check formatting
       uses: jidicula/clang-format-action@v4.4.0
       with:

--- a/.github/workflows/cmake-format-check.yml
+++ b/.github/workflows/cmake-format-check.yml
@@ -14,7 +14,7 @@ jobs:
       image: "localhost:5000/kamping-ci"
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Delete extern directory
       # Very hacky but the action doesn't allow excluding directories
       # and for some reason the checkout action checks out submodules even though it shouldn't

--- a/.github/workflows/doxygen-check.yml
+++ b/.github/workflows/doxygen-check.yml
@@ -14,7 +14,7 @@ jobs:
     container:
       image: "localhost:5000/kamping-ci"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: 'recursive'
       - name: version


### PR DESCRIPTION
Right now, there are warnings because of an old node.js version (see [here](https://github.com/kamping-site/kamping/actions/runs/3629482942) for an example)