### PR TITLE
Add test timeout

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,7 +12,9 @@ message(STATUS "Test timeout set to ${KAMPING_TEST_TIMEOUT} seconds.")
 include(ProcessorCount)
 ProcessorCount(N)
 if (NOT N EQUAL 0)
-    add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure --timeout ${KAMPING_TEST_TIMEOUT} -j ${N})
+    add_custom_target(
+        check COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure --timeout ${KAMPING_TEST_TIMEOUT} -j ${N}
+    )
 endif ()
 
 # Registering tests without MPI:


### PR DESCRIPTION
Add a timeout of 10 seconds so tests fail when they deadlock