### PR TITLE
ResultCategoryNotUsed instead of status(ignore) in make_mpi_result

### DIFF
--- a/include/kamping/mpi_function_wrapper_helpers.hpp
+++ b/include/kamping/mpi_function_wrapper_helpers.hpp
@@ -218,9 +218,7 @@ auto make_mpi_result(Args... args) {
         args...
     );
 
-    using default_status_type = decltype(kamping::status(kamping::ignore<>));
-
-    auto&& status = internal::select_parameter_type_or_default<internal::ParameterType::status, default_status_type>(
+    auto&& status = internal::select_parameter_type_or_default<internal::ParameterType::status, default_type>(
         std::tuple(),
         args...
     );


### PR DESCRIPTION
Missed this in #450 