### PR TITLE
Feature: `Environment::abort()` as a wrapper around `MPI_Abort()`

### DIFF
--- a/include/kamping/communicator.hpp
+++ b/include/kamping/communicator.hpp
@@ -125,6 +125,15 @@ public:
         std::swap(_owns_mpi_comm, other._owns_mpi_comm);
     }
 
+    /// @brief Terminates MPI execution environment (on all processes in this Communicator).
+    /// Beware of MPI implementations who might terminate all processes, whether they are in this communicator or not.
+    ///
+    /// @param errorcode Error code to return to invoking environment.
+    void abort(int errorcode = 1) const {
+        [[maybe_unused]] int err = MPI_Abort(_comm, errorcode);
+        THROW_IF_MPI_ERROR(err, MPI_Abort);
+    }
+
     /// @brief Rank of the current MPI process in the communicator as `int`.
     /// @return Rank of the current MPI process in the communicator as `int`.
     [[nodiscard]] int rank_signed() const {

--- a/include/kamping/environment.hpp
+++ b/include/kamping/environment.hpp
@@ -122,17 +122,6 @@ public:
         return result == true;
     }
 
-    /// @brief Terminates MPI execution environment (all processes in MPI_COMM_WORLD).
-    ///
-    /// @param errorcode Error code to return to invoking environment.
-    void abort(int errorcode) const {
-        // According to the MPICH documentation (https://www.mpich.org/static/docs/v3.1/www3/MPI_Abort.html)
-        // In most systems (all to date), terminates all processes, regardless of if they're in the provided
-        // communicator or not. Thus, we can just pass MPI_COMM_WORLD.
-        [[maybe_unused]] int err = MPI_Abort(MPI_COMM_WORLD, errorcode);
-        THROW_IF_MPI_ERROR(err, MPI_Abort);
-    }
-
     /// @brief Checks whether MPI_Finalize has been called.
     ///
     /// @return \c true if MPI_Finalize has been called, \c false otherwise.


### PR DESCRIPTION
I need this for integrating KaMPIng into RAxML-ng