### PR TITLE
Remove obsolete tests/test_assertions.hpp and all references to it

### DIFF
--- a/tests/collectives/mpi_exscan_test.cpp
+++ b/tests/collectives/mpi_exscan_test.cpp
@@ -11,6 +11,8 @@
 // You should have received a copy of the GNU Lesser General Public License along with KaMPIng.  If not, see
 // <https://www.gnu.org/licenses/>.
 
+#include "../test_assertions.hpp"
+
 #include <gtest/gtest.h>
 
 #include "../helpers_for_testing.hpp"

--- a/tests/collectives/mpi_reduce_test.cpp
+++ b/tests/collectives/mpi_reduce_test.cpp
@@ -11,6 +11,8 @@
 // You should have received a copy of the GNU Lesser General Public License along with KaMPIng.  If not, see
 // <https://www.gnu.org/licenses/>.
 
+#include "../test_assertions.hpp"
+
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 

--- a/tests/collectives/mpi_scan_test.cpp
+++ b/tests/collectives/mpi_scan_test.cpp
@@ -12,6 +12,8 @@
 // You should have received a copy of the GNU Lesser General Public License along with KaMPIng.  If not, see
 // <https://www.gnu.org/licenses/>.
 
+#include "../test_assertions.hpp"
+
 #include <gtest/gtest.h>
 
 #include "../helpers_for_testing.hpp"

--- a/tests/environment_test.cpp
+++ b/tests/environment_test.cpp
@@ -11,6 +11,8 @@
 // You should have received a copy of the GNU Lesser General Public License along with KaMPIng.  If not, see
 // <https://www.gnu.org/licenses/>.
 
+#include "test_assertions.hpp"
+
 #include <chrono>
 #include <set>
 #include <thread>
@@ -34,7 +36,7 @@ int MPI_Type_free(MPI_Datatype* type) {
     return PMPI_Type_free(type);
 }
 
-struct EnvironmentTest : testing::Test {
+struct EnvironmentTest : ::testing::Test {
     void SetUp() override {
         int  flag;
         int* value;

--- a/tests/helpers_for_testing.hpp
+++ b/tests/helpers_for_testing.hpp
@@ -21,15 +21,8 @@
 #include <cstdlib>
 #include <initializer_list>
 #include <memory>
-#include <vector>
 
-#include <gtest/gtest.h>
-#include <kassert/kassert.hpp>
-
-#include "kamping/assertion_levels.hpp"
-#include "kamping/data_buffer.hpp"
 #include "kamping/named_parameter_types.hpp"
-#include "kamping/result.hpp"
 
 namespace testing {
 /// @brief Simple Container type. Can be used to test library function with containers other than vector.
@@ -199,32 +192,6 @@ struct CustomAllocator {
         free(p);
     }
 };
-
-//
-// Makros to test for failed KASSERT() statements.
-// Note that these macros could already be defined if we included the header that turns assertions into exceptions.
-// In this case, we keep the current definition.
-//
-
-#ifndef EXPECT_KASSERT_FAILS
-    #if KASSERT_ENABLED(KAMPING_ASSERTION_LEVEL_HEAVY)
-        // EXPECT that a KASSERT assertion failed and that the error message contains a certain failure_message.
-        #define EXPECT_KASSERT_FAILS(code, failure_message) \
-            EXPECT_EXIT({ code; }, testing::KilledBySignal(SIGABRT), failure_message);
-    #else // Otherwise, we do not test for failed assertions
-        #define EXPECT_KASSERT_FAILS(code, failure_message)
-    #endif
-#endif
-
-#ifndef ASSERT_KASSERT_FAILS
-    #if KASSERT_ENABLED(KAMPING_ASSERTION_LEVEL_HEAVY)
-        // ASSERT that a KASSERT assertion failed and that the error message contains a certain failure_message.
-        #define ASSERT_KASSERT_FAILS(code, failure_message) \
-            ASSERT_EXIT({ code; }, testing::KilledBySignal(SIGABRT), failure_message);
-    #else // Otherwise, we do not test for failed assertions
-        #define ASSERT_KASSERT_FAILS(code, failure_message)
-    #endif
-#endif
 
 /// @}
 } // namespace testing

--- a/tests/mpi_communicator_test.cpp
+++ b/tests/mpi_communicator_test.cpp
@@ -11,6 +11,8 @@
 // You should have received a copy of the GNU Lesser General Public License along with KaMPIng.  If not, see
 // <https://www.gnu.org/licenses/>.
 
+#include "test_assertions.hpp"
+
 #include <limits>
 #include <numeric>
 #include <vector>
@@ -19,7 +21,6 @@
 #include <kassert/kassert.hpp>
 #include <mpi.h>
 
-#include "helpers_for_testing.hpp"
 #include "kamping/comm_helper/num_numa_nodes.hpp"
 #include "kamping/communicator.hpp"
 

--- a/tests/nonblocking_result_test.cpp
+++ b/tests/nonblocking_result_test.cpp
@@ -11,10 +11,11 @@
 // You should have received a copy of the GNU Lesser General Public License along with KaMPIng.  If not, see
 // <https://www.gnu.org/licenses/>.
 
+#include "test_assertions.hpp"
+
 #include <gtest/gtest.h>
 #include <mpi.h>
 
-#include "helpers_for_testing.hpp"
 #include "kamping/named_parameters.hpp"
 #include "kamping/result.hpp"
 

--- a/tests/p2p/mpi_recv_test.cpp
+++ b/tests/p2p/mpi_recv_test.cpp
@@ -13,6 +13,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with KaMPIng.  If not, see <https://www.gnu.org/licenses/>.
 
+#include "../test_assertions.hpp"
+
 #include <gtest/gtest.h>
 #include <mpi.h>
 
@@ -373,9 +375,9 @@ TEST_F(RecvTest, recv_vector_with_input_status) {
 }
 
 TEST_F(RecvTest, recv_default_custom_container_without_recv_buf) {
-    Communicator<testing::OwnContainer> comm;
-    std::vector                         v{1, 2, 3, 4, 5};
-    MPI_Request                         req = MPI_REQUEST_NULL;
+    Communicator<::testing::OwnContainer> comm;
+    std::vector                           v{1, 2, 3, 4, 5};
+    MPI_Request                           req = MPI_REQUEST_NULL;
     if (comm.is_root()) {
         auto other_rank = comm.rank_shifted_cyclic(1);
         MPI_Isend(
@@ -394,11 +396,11 @@ TEST_F(RecvTest, recv_default_custom_container_without_recv_buf) {
         EXPECT_TRUE(has_member_extract_recv_counts_v<decltype(result)>);
         EXPECT_FALSE(has_member_extract_status_v<decltype(result)>);
         EXPECT_TRUE(has_member_extract_recv_buffer_v<decltype(result)>);
-        testing::OwnContainer<int> message = result.extract_recv_buffer();
+        ::testing::OwnContainer<int> message = result.extract_recv_buffer();
         // we should not probe for the message size inside of KaMPIng if we specify the recv count explicitly
         EXPECT_EQ(probe_counter, 1);
         EXPECT_EQ(result.extract_recv_counts(), 5);
-        EXPECT_EQ(message, testing::OwnContainer<int>({1, 2, 3, 4, 5}));
+        EXPECT_EQ(message, ::testing::OwnContainer<int>({1, 2, 3, 4, 5}));
     }
     MPI_Wait(&req, MPI_STATUS_IGNORE);
 }

--- a/tests/result_test.cpp
+++ b/tests/result_test.cpp
@@ -184,57 +184,57 @@ void test_send_displs_in_MPIResult() {
 
 TEST(MpiResultTest, has_extract_v_basics) {
     static_assert(
-        has_extract_v<testing::StructWithExtract>,
+        has_extract_v<::testing::StructWithExtract>,
         "StructWithExtract contains extract() member function -> needs to be detected."
     );
     static_assert(
-        !has_extract_v<testing::StructWithoutExtract>,
+        !has_extract_v<::testing::StructWithoutExtract>,
         "StructWithoutExtract does not contain extract() member function."
     );
 }
 
 TEST(MpiResultTest, extract_recv_buffer_basics) {
-    testing::test_recv_buffer_in_MPIResult<std::vector<int>>();
+    ::testing::test_recv_buffer_in_MPIResult<std::vector<int>>();
 }
 
 TEST(MpiResultTest, extract_recv_buffer_basics_own_container) {
-    testing::test_recv_buffer_in_MPIResult<testing::OwnContainer<int>>();
+    ::testing::test_recv_buffer_in_MPIResult<::testing::OwnContainer<int>>();
 }
 
 TEST(MpiResultTest, extract_recv_counts_basics) {
-    testing::test_recv_counts_in_MPIResult<std::vector<int>>();
+    ::testing::test_recv_counts_in_MPIResult<std::vector<int>>();
 }
 
 TEST(MpiResultTest, extract_recv_counts_basics_own_container) {
-    testing::test_recv_counts_in_MPIResult<testing::OwnContainer<int>>();
+    ::testing::test_recv_counts_in_MPIResult<::testing::OwnContainer<int>>();
 }
 
 TEST(MpiResultTest, extract_recv_count_basics) {
-    testing::test_recv_count_in_MPIResult();
+    ::testing::test_recv_count_in_MPIResult();
 }
 
 TEST(MpiResultTest, extract_recv_displs_basics) {
-    testing::test_recv_displs_in_MPIResult<std::vector<int>>();
+    ::testing::test_recv_displs_in_MPIResult<std::vector<int>>();
 }
 
 TEST(MpiResultTest, extract_recv_displs_basics_own_container) {
-    testing::test_recv_displs_in_MPIResult<testing::OwnContainer<int>>();
+    ::testing::test_recv_displs_in_MPIResult<::testing::OwnContainer<int>>();
 }
 
 TEST(MpiResultTest, extract_send_counts_basics) {
-    testing::test_send_counts_in_MPIResult<std::vector<int>>();
+    ::testing::test_send_counts_in_MPIResult<std::vector<int>>();
 }
 
 TEST(MpiResultTest, extract_send_counts_basics_own_container) {
-    testing::test_send_counts_in_MPIResult<testing::OwnContainer<int>>();
+    ::testing::test_send_counts_in_MPIResult<::testing::OwnContainer<int>>();
 }
 
 TEST(MpiResultTest, extract_send_displs_basics) {
-    testing::test_send_displs_in_MPIResult<std::vector<int>>();
+    ::testing::test_send_displs_in_MPIResult<std::vector<int>>();
 }
 
 TEST(MpiResultTest, extract_send_displs_basics_own_container) {
-    testing::test_send_displs_in_MPIResult<testing::OwnContainer<int>>();
+    ::testing::test_send_displs_in_MPIResult<::testing::OwnContainer<int>>();
 }
 
 TEST(MpiResultTest, extract_send_recv_count) {

--- a/tests/test_assertions_death.hpp
+++ b/tests/test_assertions_death.hpp
@@ -1,0 +1,49 @@
+// This file is part of KaMPIng.
+//
+// Copyright 2021-2023 The KaMPIng Authors
+//
+// KaMPIng is free software : you can redistribute it and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
+// version. KaMPIng is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+// implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+// for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along with KaMPIng.  If not, see
+// <https://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include <kassert/kassert.hpp>
+
+#include "kamping/assertion_levels.hpp"
+
+//
+// Makros to test for failed KASSERT() statements by using a death test. This is usually only a last resort, when we
+// want to test KASSERTs in places which are not allowed to throw exceptions.
+//
+// See test_assertions.hpp for the exception overriding version.
+//
+// Note that these macros could already be defined if we included the header that turns assertions into exceptions. In
+// this case, we keep the current definition.
+//
+
+#ifndef EXPECT_KASSERT_FAILS_WITH_DEATH
+    #if KASSERT_ENABLED(KAMPING_ASSERTION_LEVEL_HEAVY)
+        // EXPECT that a KASSERT assertion failed and that the error message contains a certain failure_message.
+        #define EXPECT_KASSERT_FAILS_WITH_DEATH(code, failure_message) \
+            EXPECT_EXIT({ code; }, testing::KilledBySignal(SIGABRT), failure_message);
+    #else // Otherwise, we do not test for failed assertions
+        #define EXPECT_KASSERT_FAILS_WITH_DEATH(code, failure_message)
+    #endif
+#endif
+
+#ifndef ASSERT_KASSERT_FAILS_WITH_DEATH
+    #if KASSERT_ENABLED(KAMPING_ASSERTION_LEVEL_HEAVY)
+        // ASSERT that a KASSERT assertion failed and that the error message contains a certain failure_message.
+        #define ASSERT_KASSERT_FAILS_WITH_DEATH(code, failure_message) \
+            ASSERT_EXIT({ code; }, testing::KilledBySignal(SIGABRT), failure_message);
+    #else // Otherwise, we do not test for failed assertions
+        #define ASSERT_KASSERT_FAILS_WITH_DEATH(code, failure_message)
+    #endif
+#endif


### PR DESCRIPTION
We have multiple (different) redefinitions of `KASSERT_KASSERT_HPP_KASSERT_IMPL` for testing with `KASSERT`s. One in 
`tests/test_assertions.hpp` (used in three files) and one in `tests/test_helpers.hpp` (used everywhere else).

@niklas-uhl and I decided to just try to remove the lesser used version and see what happens even though we vaguely remembered what happened now: If the `KASSERT` fails only one some ranks, the test will fail.

The two redefinitions of `KASSERT_KASSERT_HPP_KASSERT_IMPL` take the following two approaches:

`tests/test_assertions.hpp`: Make `KASSERT` throw an exception on error. Will give a compilation warning (=error) for `KASSERT`s in destructors because they might throw during stack unwinding which will `std::terminate()`.

`tests/assertion_helpers.hpp`: Use GoogleTest's death tests to check if the program failed with a specific error message. Breaks some assertions as described above.

We thus need to do some of the following:
- Rename one of the implementations.
- Provide a `KASSERT_DESTRUCTOR` which doesn't get overwritten or don't use `KASSERT` in destructors
- Find a solution which works in both cases

@DanielSeemaier originally implemented those two methods, so his input might be valueable.