### PR TITLE
Add additional test for iprobe.

### DIFF
--- a/tests/p2p/mpi_iprobe_test.cpp
+++ b/tests/p2p/mpi_iprobe_test.cpp
@@ -528,3 +528,8 @@ TEST_F(IProbeTest, nothing_to_probe) {
     Communicator comm;
     EXPECT_FALSE(comm.iprobe());
 }
+
+TEST_F(IProbeTest, nothing_to_probe_with_status) {
+    Communicator comm;
+    EXPECT_FALSE(comm.iprobe(status_out()).has_value());
+}


### PR DESCRIPTION
This checks if iprobe is able to return a valid nullopt.