### PR TITLE
Update CI image.

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.10
+FROM ubuntu:jammy
 
 # This Dockerfile is not directly used in the workflows. It is the one used on our self-hosted runner though and only here for documentation.
 
@@ -15,7 +15,7 @@ RUN apt-get install flex bison graphviz texlive-full -y
 RUN curl -fsSL https://get.docker.com -o get-docker.sh && sh get-docker.sh
 
 # install Doxygen (newer versions that available in the package repositories)
-ARG DOXYGEN_VERSION=1.9.3
+ARG DOXYGEN_VERSION=1.10.0
 RUN wget https://www.doxygen.nl/files/doxygen-$DOXYGEN_VERSION.src.tar.gz && \
     tar -xzf doxygen-$DOXYGEN_VERSION.src.tar.gz && \
     cd doxygen-$DOXYGEN_VERSION && \
@@ -23,7 +23,7 @@ RUN wget https://www.doxygen.nl/files/doxygen-$DOXYGEN_VERSION.src.tar.gz && \
     make -j && make install
 
 # install cmake
-ARG CMAKE_VERSION=3.21.0
+ARG CMAKE_VERSION=3.28.3
 RUN wget https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-linux-x86_64.sh && \
     sh ./cmake-$CMAKE_VERSION-linux-x86_64.sh --skip-license --prefix=/usr/local && \
     rm cmake-$CMAKE_VERSION-linux-x86_64.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 10
     container:
-      image: "localhost:5000/kamping-ci"
+      image: "localhost:5000/kamping-ci:2024.1"
     continue-on-error: true
     strategy:
       matrix:

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -11,7 +11,7 @@ jobs:
     name: C++ Formatting Check
     runs-on: self-hosted
     container:
-      image: "localhost:5000/kamping-ci"
+      image: "localhost:5000/kamping-ci:2024.1"
     steps:
     - uses: actions/checkout@v3
     - name: Check formatting

--- a/.github/workflows/cmake-format-check.yml
+++ b/.github/workflows/cmake-format-check.yml
@@ -11,7 +11,7 @@ jobs:
     name: CMake Formatting Check
     runs-on: self-hosted
     container:
-      image: "localhost:5000/kamping-ci"
+      image: "localhost:5000/kamping-ci:2024.1"
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3

--- a/.github/workflows/doxygen-check.yml
+++ b/.github/workflows/doxygen-check.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 10
     container:
-      image: "localhost:5000/kamping-ci"
+      image: "localhost:5000/kamping-ci:2024.1"
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Update the following components and use explicit tags in workflows.

- Ubuntu 21.10 -> 22.04
- Doxygen 1.9.3 -> 1.10.0
- CMake 3.21.0 -> 3.28.3