### PR TITLE
adapt nonblocking result to structure of blocking result

### DIFF
--- a/include/kamping/collectives/ibarrier.hpp
+++ b/include/kamping/collectives/ibarrier.hpp
@@ -23,7 +23,7 @@
 #include "kamping/named_parameters.hpp"
 #include "kamping/parameter_objects.hpp"
 #include "kamping/request.hpp"
-#include "kamping/result.hpp"
+#include "kamping/result_.hpp"
 
 /// @brief Perform a non-blocking barrier synchronization on this communicator using \c MPI_Ibarrier. The call is
 /// associated with a \ref kamping::Request (either allocated by KaMPIng or provided by the user). Only when the request
@@ -54,5 +54,5 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::ibarrier(Args... a
     );
     THROW_IF_MPI_ERROR(err, MPI_Ibarrier);
 
-    return make_nonblocking_result(std::move(request_param));
+    return internal::make_nonblocking_result_<std::tuple<Args...>>(std::move(request_param));
 }

--- a/include/kamping/p2p/irecv.hpp
+++ b/include/kamping/p2p/irecv.hpp
@@ -34,7 +34,7 @@
 #include "kamping/p2p/probe.hpp"
 #include "kamping/parameter_objects.hpp"
 #include "kamping/request.hpp"
-#include "kamping/result.hpp"
+#include "kamping/result_.hpp"
 #include "kamping/status.hpp"
 
 /// @brief Wrapper for \c MPI_Recv.
@@ -173,7 +173,7 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::irecv(Args... args
     );
     THROW_IF_MPI_ERROR(err, MPI_Irecv);
 
-    return make_nonblocking_result(
+    return internal::make_nonblocking_result_<std::tuple<Args...>>(
         std::move(recv_buf),
         std::move(recv_count_param),
         std::move(recv_type),

--- a/include/kamping/p2p/isend.hpp
+++ b/include/kamping/p2p/isend.hpp
@@ -31,7 +31,7 @@
 #include "kamping/p2p/helpers.hpp"
 #include "kamping/parameter_objects.hpp"
 #include "kamping/request.hpp"
-#include "kamping/result.hpp"
+#include "kamping/result_.hpp"
 
 /// @brief Wrapper for \c MPI_Isend.
 ///
@@ -173,7 +173,7 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::isend(Args... args
         );
         THROW_IF_MPI_ERROR(err, MPI_Irsend);
     }
-    return make_nonblocking_result(std::move(request_param));
+    return make_nonblocking_result_<std::tuple<Args...>>(std::move(request_param));
 }
 
 /// @brief Convenience wrapper for MPI_Ibsend. Calls \ref kamping::Communicator::isend() with the appropriate send mode

--- a/tests/p2p/mpi_isend_test.cpp
+++ b/tests/p2p/mpi_isend_test.cpp
@@ -253,7 +253,7 @@ TEST_F(ISendTest, send_vector_with_enum_tag_recv_out_of_order) {
     Communicator comm;
     auto         other_rank = (comm.root() + 1) % comm.size();
     if (comm.is_root()) {
-        auto [req1, _r1] =
+        auto req1 =
             comm.isend(send_buf(std::vector<int>{}), destination(other_rank), tag(Tag::control_message)).extract();
         ASSERT_EQ(isend_counter, 1);
         ASSERT_EQ(ibsend_counter, 0);
@@ -261,7 +261,7 @@ TEST_F(ISendTest, send_vector_with_enum_tag_recv_out_of_order) {
         ASSERT_EQ(irsend_counter, 0);
 
         std::vector<int> values{42, 3, 8, 7};
-        auto [req2, _r2] = comm.isend(send_buf(values), destination(other_rank), tag(Tag::data_message)).extract();
+        auto             req2 = comm.isend(send_buf(values), destination(other_rank), tag(Tag::data_message)).extract();
         ASSERT_EQ(isend_counter, 2);
         ASSERT_EQ(ibsend_counter, 0);
         ASSERT_EQ(issend_counter, 0);


### PR DESCRIPTION
Note that I changed the return type of `NonBlockingResult_.extract()`.
We can discuss whether this is reasonable.
