### PR TITLE
Ensure that an attached buffer has at least size bsend overhead.

### DIFF
--- a/include/kamping/environment.hpp
+++ b/include/kamping/environment.hpp
@@ -215,8 +215,8 @@ public:
         internal::registered_mpi_types.clear();
     }
 
-    static size_t const bsend_overhead = MPI_BSEND_OVERHEAD; ///< Provides an upper bound on the additional memory
-                                                             ///< required by buffered send operations.
+    static inline size_t const bsend_overhead = MPI_BSEND_OVERHEAD; ///< Provides an upper bound on the additional
+                                                                    ///< memory required by buffered send operations.
 
     /// @brief Attach a buffer to use for buffered send operations to the environment.
     ///


### PR DESCRIPTION
MPICH fails if this is not the case.