### PR TITLE
In the ULFM example, revoke the communicator only once

### DIFF
--- a/examples/applications/ulfm.cpp
+++ b/examples/applications/ulfm.cpp
@@ -32,7 +32,9 @@ int main(int argc, char** argv) {
             comm.allreduce(send_recv_buf(result), op(kamping::ops::plus<>()));
             KASSERT(!comm.is_revoked());
         } catch ([[maybe_unused]] MPIFailureDetected const& _) {
-            comm.revoke();
+            if (!comm.is_revoked()) {
+                comm.revoke();
+            }
             comm = comm.shrink();
             if (comm.rank() == root) {
                 std::cerr << "Process failure detected and recovered from. Remaining ranks: " << comm.size()


### PR DESCRIPTION
If the communicator has already been revoked by another process, we don't need to re-revoke it. (Now possible, because #662 is merged).