### PR TITLE
Fix/do not store owning data as const

### DIFF
--- a/include/kamping/data_buffer.hpp
+++ b/include/kamping/data_buffer.hpp
@@ -171,8 +171,8 @@ static constexpr bool is_vector_bool_v<
 template <typename T>
 static constexpr bool
     is_vector_bool_v<T, typename std::enable_if<has_value_type_v<std::remove_cv_t<std::remove_reference_t<T>>>>::type> =
-        is_specialization<std::remove_cv_t<std::remove_reference_t<T>>, std::vector>::value
-        && std::is_same_v<typename std::remove_cv_t<std::remove_reference_t<T>>::value_type, bool>;
+        is_specialization<std::remove_cv_t<std::remove_reference_t<T>>, std::vector>::value&&
+            std::is_same_v<typename std::remove_cv_t<std::remove_reference_t<T>>::value_type, bool>;
 
 KAMPING_MAKE_HAS_MEMBER(resize)
 
@@ -519,8 +519,7 @@ public:
     /// is not called if the buffer's resize policy is BufferResizePolicy::no_resize.
     template <typename SizeFunc>
     void resize_if_requested(SizeFunc&& compute_required_size) {
-        if constexpr (resize_policy == BufferResizePolicy::resize_to_fit
-                      || resize_policy == BufferResizePolicy::grow_only) {
+        if constexpr (resize_policy == BufferResizePolicy::resize_to_fit || resize_policy == BufferResizePolicy::grow_only) {
             resize(compute_required_size());
         }
     }

--- a/include/kamping/data_buffer.hpp
+++ b/include/kamping/data_buffer.hpp
@@ -604,6 +604,10 @@ public:
             "Moving out of a reference should not be done because it would leave "
             "a users container in an unspecified state."
         );
+        static_assert(
+            !is_vector_bool_v<MemberType>,
+            "Buffers based on std::vector<bool> are not supported, use std::vector<kamping::kabool> instead."
+        );
         kassert_not_extracted("Cannot extract a buffer that has already been extracted.");
         auto extracted = std::move(_data);
         // we set is_extracted here because otherwise the call to underlying() would fail

--- a/tests/data_buffer_test.cpp
+++ b/tests/data_buffer_test.cpp
@@ -1185,3 +1185,5 @@ TEST(DataBufferTest, referencing_buffers_are_copyable) {
         [[maybe_unused]] auto buffer2 = std::move(buffer_based_on_const_int_vector);
     }
 }
+
+    using StorageType = std::conditional_t<is_owning, MemberType, MemberTypeWithConstAndRef>;

--- a/tests/data_buffer_test.cpp
+++ b/tests/data_buffer_test.cpp
@@ -1185,5 +1185,3 @@ TEST(DataBufferTest, referencing_buffers_are_copyable) {
         [[maybe_unused]] auto buffer2 = std::move(buffer_based_on_const_int_vector);
     }
 }
-
-using StorageType = std::conditional_t<is_owning, MemberType, MemberTypeWithConstAndRef>;

--- a/tests/data_buffer_test.cpp
+++ b/tests/data_buffer_test.cpp
@@ -1186,4 +1186,4 @@ TEST(DataBufferTest, referencing_buffers_are_copyable) {
     }
 }
 
-    using StorageType = std::conditional_t<is_owning, MemberType, MemberTypeWithConstAndRef>;
+using StorageType = std::conditional_t<is_owning, MemberType, MemberTypeWithConstAndRef>;

--- a/tests/named_parameters_test.cpp
+++ b/tests/named_parameters_test.cpp
@@ -407,9 +407,12 @@ TEST(ParameterFactoriesTest, send_buf_ignored) {
 
 TEST(ParameterFactoriesTest, send_buf_owning_move_only_data) {
     // test that data within the buffer is still treated as constant but can be returned without being copied
-    testing::NonCopyableOwnContainer<int> vec{1, 2, 3, 4}; // required as original data will be moved to buffer
-    testing::NonCopyableOwnContainer<int> const
-         expected_vec{1, 2, 3, 4}; // required as original data will be moved to buffer
+    testing::NonCopyableOwnContainer<int>       vec{1, 2, 3, 4}; // required as original data will be moved to buffer
+    testing::NonCopyableOwnContainer<int> const expected_vec{
+        1,
+        2,
+        3,
+        4}; // required as original data will be moved to buffer
     auto send_buffer = send_buf(std::move(vec)).construct_buffer_or_rebind();
     testing::test_const_owning_buffer<int>(
         send_buffer,
@@ -475,9 +478,12 @@ TEST(ParameterFactoriesTest, send_counts_basics_initializer_list) {
 
 TEST(ParameterFactoriesTest, send_counts_owning_move_only_data) {
     // test that data within the buffer is still treated as constant but can be returned without being copied
-    testing::NonCopyableOwnContainer<int> vec{1, 2, 3, 4}; // required as original data will be moved to buffer
-    testing::NonCopyableOwnContainer<int> const
-         expected_vec{1, 2, 3, 4}; // required as original data will be moved to buffer
+    testing::NonCopyableOwnContainer<int>       vec{1, 2, 3, 4}; // required as original data will be moved to buffer
+    testing::NonCopyableOwnContainer<int> const expected_vec{
+        1,
+        2,
+        3,
+        4}; // required as original data will be moved to buffer
     auto send_buffer = send_counts(std::move(vec)).construct_buffer_or_rebind();
     testing::test_const_owning_buffer<int>(
         send_buffer,
@@ -593,9 +599,12 @@ TEST(ParameterFactoriesTest, send_displs_in_basics_initializer_list) {
 
 TEST(ParameterFactoriesTest, send_displs_owning_move_only_data) {
     // test that data within the buffer is still treated as constant but can be returned without being copied
-    testing::NonCopyableOwnContainer<int> vec{1, 2, 3, 4}; // required as original data will be moved to buffer
-    testing::NonCopyableOwnContainer<int> const
-         expected_vec{1, 2, 3, 4}; // required as original data will be moved to buffer
+    testing::NonCopyableOwnContainer<int>       vec{1, 2, 3, 4}; // required as original data will be moved to buffer
+    testing::NonCopyableOwnContainer<int> const expected_vec{
+        1,
+        2,
+        3,
+        4}; // required as original data will be moved to buffer
     auto send_buffer = send_displs(std::move(vec)).construct_buffer_or_rebind();
     testing::test_const_owning_buffer<int>(
         send_buffer,

--- a/tests/parameter_objects_test.cpp
+++ b/tests/parameter_objects_test.cpp
@@ -105,7 +105,7 @@ TEST(ParameterObjectsTest, DataBufferBuilder_with_const_owning_noncopyable_type)
         container[0] = 42;
         EXPECT_EQ(b.size(), 4);
         auto           buffer                 = b.construct_buffer_or_rebind();
-        constexpr bool is_data_ptr_constant   = std::is_const_v<std::remove_pointer_t<decltype(*buffer.data())>>;
+        constexpr bool is_data_ptr_constant   = std::is_const_v<std::remove_pointer_t<decltype(buffer.data())>>;
         constexpr bool is_underlying_constant = std::is_const_v<std::remove_reference_t<decltype(buffer.underlying())>>;
         EXPECT_TRUE(is_data_ptr_constant);
         EXPECT_TRUE(is_underlying_constant);

--- a/tests/parameter_objects_test.cpp
+++ b/tests/parameter_objects_test.cpp
@@ -59,10 +59,10 @@ TEST(ParameterObjectsTest, DataBufferBuilder_with_noncopyable_type) {
     { // by reference
         testing::NonCopyableOwnContainer<int> container{1, 2, 3, 4};
         auto                                  b = make_data_buffer_builder<
-                                             kamping::internal::ParameterType::recv_buf,
-                                             kamping::internal::BufferModifiability::modifiable,
-                                             kamping::internal::BufferType::out_buffer,
-                                             resize_to_fit>(container);
+            kamping::internal::ParameterType::recv_buf,
+            kamping::internal::BufferModifiability::modifiable,
+            kamping::internal::BufferType::out_buffer,
+            resize_to_fit>(container);
         container[0] = 42;
         EXPECT_EQ(b.size(), 4);
         auto buffer = b.construct_buffer_or_rebind();
@@ -72,10 +72,10 @@ TEST(ParameterObjectsTest, DataBufferBuilder_with_noncopyable_type) {
     { // by value
         testing::NonCopyableOwnContainer<int> container{1, 2, 3, 4};
         auto                                  b = make_data_buffer_builder<
-                                             kamping::internal::ParameterType::recv_buf,
-                                             kamping::internal::BufferModifiability::modifiable,
-                                             kamping::internal::BufferType::out_buffer,
-                                             resize_to_fit>(std::move(container));
+            kamping::internal::ParameterType::recv_buf,
+            kamping::internal::BufferModifiability::modifiable,
+            kamping::internal::BufferType::out_buffer,
+            resize_to_fit>(std::move(container));
         container.resize(1);
         container[0] = 42;
         EXPECT_EQ(b.size(), 4);
@@ -97,16 +97,16 @@ TEST(ParameterObjectsTest, DataBufferBuilder_with_const_owning_noncopyable_type)
     {
         testing::NonCopyableOwnContainer<int> container{1, 2, 3, 4};
         auto                                  b = make_data_buffer_builder<
-                                             kamping::internal::ParameterType::recv_buf,
-                                             kamping::internal::BufferModifiability::constant,
-                                             kamping::internal::BufferType::out_buffer,
-                                             no_resize>(std::move(container));
+            kamping::internal::ParameterType::recv_buf,
+            kamping::internal::BufferModifiability::constant,
+            kamping::internal::BufferType::out_buffer,
+            no_resize>(std::move(container));
         container.resize(1);
         container[0] = 42;
         EXPECT_EQ(b.size(), 4);
         auto           buffer                 = b.construct_buffer_or_rebind();
         constexpr bool is_data_ptr_constant   = std::is_const_v<std::remove_pointer_t<decltype(*buffer.data())>>;
-        constexpr bool is_underlying_constant = std::is_const_v<<decltype(buffer.underlying())>>;
+        constexpr bool is_underlying_constant = std::is_const_v << decltype(buffer.underlying()) >> ;
         EXPECT_TRUE(is_data_ptr_constant);
         EXPECT_TRUE(is_underlying_constant);
         EXPECT_THAT(buffer.underlying(), ElementsAre(1, 2, 3, 4));

--- a/tests/parameter_objects_test.cpp
+++ b/tests/parameter_objects_test.cpp
@@ -106,7 +106,7 @@ TEST(ParameterObjectsTest, DataBufferBuilder_with_const_owning_noncopyable_type)
         EXPECT_EQ(b.size(), 4);
         auto           buffer                 = b.construct_buffer_or_rebind();
         constexpr bool is_data_ptr_constant   = std::is_const_v<std::remove_pointer_t<decltype(*buffer.data())>>;
-        constexpr bool is_underlying_constant = std::is_const_v << decltype(buffer.underlying()) >> ;
+        constexpr bool is_underlying_constant = std::is_const_v<std::remove_reference_t<decltype(buffer.underlying())>>;
         EXPECT_TRUE(is_data_ptr_constant);
         EXPECT_TRUE(is_underlying_constant);
         EXPECT_THAT(buffer.underlying(), ElementsAre(1, 2, 3, 4));


### PR DESCRIPTION
We should avoid storing the underlying data as const in constant owning data buffers. While using const ensures read-only access via C++'s constness guarantees, it also results in unnecessary data copying when attempting to extract the data. Moreover, this approach prevents storing move-only types altogether.