### PR TITLE
Fix dangling reference warning with GCC 14.

### DIFF
--- a/include/kamping/collectives/allgather.hpp
+++ b/include/kamping/collectives/allgather.hpp
@@ -88,13 +88,13 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::allgather(Args... 
         );
 
         // get the send/recv buffer and types
-        auto&& send_buf_param =
+        auto send_buf_param =
             internal::select_parameter_type<internal::ParameterType::send_buf>(args...).construct_buffer_or_rebind();
         auto send_buf         = send_buf_param.get();
         using send_value_type = typename std::remove_reference_t<decltype(send_buf_param)>::value_type;
 
         using default_recv_buf_type = decltype(kamping::recv_buf(alloc_new<DefaultContainerType<send_value_type>>));
-        auto&& recv_buf =
+        auto recv_buf =
             internal::select_parameter_type_or_default<internal::ParameterType::recv_buf, default_recv_buf_type>(
                 std::tuple(),
                 args...
@@ -102,7 +102,7 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::allgather(Args... 
                 .template construct_buffer_or_rebind<DefaultContainerType>();
         using recv_value_type = typename std::remove_reference_t<decltype(recv_buf)>::value_type;
 
-        auto&& [send_type, recv_type] =
+        auto [send_type, recv_type] =
             internal::determine_mpi_datatypes<send_value_type, recv_value_type, decltype(recv_buf)>(args...);
         [[maybe_unused]] constexpr bool send_type_is_input_parameter = !has_to_be_computed<decltype(send_type)>;
         [[maybe_unused]] constexpr bool recv_type_is_input_parameter = !has_to_be_computed<decltype(recv_type)>;
@@ -119,7 +119,7 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::allgather(Args... 
 
         // get the send counts
         using default_send_count_type = decltype(kamping::send_count_out());
-        auto&& send_count =
+        auto send_count =
             internal::select_parameter_type_or_default<internal::ParameterType::send_count, default_send_count_type>(
                 std::tuple(),
                 args...
@@ -132,7 +132,7 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::allgather(Args... 
 
         // get the receive counts
         using default_recv_count_type = decltype(kamping::recv_count_out());
-        auto&& recv_count =
+        auto recv_count =
             internal::select_parameter_type_or_default<internal::ParameterType::recv_count, default_recv_count_type>(
                 std::tuple(),
                 args...
@@ -215,11 +215,11 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::allgather_inplace(
     );
 
     // get the send/recv buffer and type
-    auto&& buffer =
+    auto buffer =
         internal::select_parameter_type<internal::ParameterType::send_recv_buf>(args...).construct_buffer_or_rebind();
     using value_type = typename std::remove_reference_t<decltype(buffer)>::value_type;
 
-    auto&& type = internal::determine_mpi_send_recv_datatype<value_type, decltype(buffer)>(args...);
+    auto type = internal::determine_mpi_send_recv_datatype<value_type, decltype(buffer)>(args...);
     [[maybe_unused]] constexpr bool type_is_input_parameter = !has_to_be_computed<decltype(type)>;
 
     KASSERT(
@@ -233,7 +233,7 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::allgather_inplace(
 
     // get the send counts
     using default_count_type = decltype(kamping::send_recv_count_out());
-    auto&& count =
+    auto count =
         internal::select_parameter_type_or_default<internal::ParameterType::send_recv_count, default_count_type>(
             std::tuple(),
             args...
@@ -332,13 +332,13 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::allgatherv(Args...
     );
 
     // get send_buf
-    auto&& send_buf =
+    auto send_buf =
         internal::select_parameter_type<internal::ParameterType::send_buf>(args...).construct_buffer_or_rebind();
     using send_value_type = typename std::remove_reference_t<decltype(send_buf)>::value_type;
 
     // get recv_buf
     using default_recv_buf_type = decltype(kamping::recv_buf(alloc_new<DefaultContainerType<send_value_type>>));
-    auto&& recv_buf =
+    auto recv_buf =
         internal::select_parameter_type_or_default<internal::ParameterType::recv_buf, default_recv_buf_type>(
             std::tuple(),
             args...
@@ -347,14 +347,14 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::allgatherv(Args...
     using recv_value_type = typename std::remove_reference_t<decltype(recv_buf)>::value_type;
 
     // get send/recv types
-    auto&& [send_type, recv_type] =
+    auto [send_type, recv_type] =
         internal::determine_mpi_datatypes<send_value_type, recv_value_type, decltype(recv_buf)>(args...);
     [[maybe_unused]] constexpr bool send_type_is_input_parameter = !internal::has_to_be_computed<decltype(send_type)>;
     [[maybe_unused]] constexpr bool recv_type_is_input_parameter = !internal::has_to_be_computed<decltype(recv_type)>;
 
     // get the send counts
     using default_send_count_type = decltype(kamping::send_count_out());
-    auto&& send_count =
+    auto send_count =
         internal::select_parameter_type_or_default<internal::ParameterType::send_count, default_send_count_type>(
             std::tuple(),
             args...
@@ -366,7 +366,7 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::allgatherv(Args...
     }
     // get the recv counts
     using default_recv_counts_type = decltype(kamping::recv_counts_out(alloc_new<DefaultContainerType<int>>));
-    auto&& recv_counts =
+    auto recv_counts =
         internal::select_parameter_type_or_default<internal::ParameterType::recv_counts, default_recv_counts_type>(
             std::tuple(),
             args...
@@ -394,7 +394,7 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::allgatherv(Args...
 
     // Get recv_displs
     using default_recv_displs_type = decltype(kamping::recv_displs_out(alloc_new<DefaultContainerType<int>>));
-    auto&& recv_displs =
+    auto recv_displs =
         internal::select_parameter_type_or_default<internal::ParameterType::recv_displs, default_recv_displs_type>(
             std::tuple(),
             args...

--- a/include/kamping/collectives/allreduce.hpp
+++ b/include/kamping/collectives/allreduce.hpp
@@ -85,14 +85,14 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::allreduce(Args... 
         );
 
         // Get the send buffer and deduce the send and recv value types.
-        auto const& send_buf  = select_parameter_type<ParameterType::send_buf>(args...).construct_buffer_or_rebind();
+        auto const send_buf   = select_parameter_type<ParameterType::send_buf>(args...).construct_buffer_or_rebind();
         using send_value_type = typename std::remove_reference_t<decltype(send_buf)>::value_type;
         using default_recv_value_type = std::remove_const_t<send_value_type>;
 
         // Deduce the recv buffer type and get (if provided) the recv buffer or allocate one (if not provided).
         using default_recv_buf_type =
             decltype(kamping::recv_buf(alloc_new<DefaultContainerType<default_recv_value_type>>));
-        auto&& recv_buf =
+        auto recv_buf =
             select_parameter_type_or_default<ParameterType::recv_buf, default_recv_buf_type>(std::tuple(), args...)
                 .template construct_buffer_or_rebind<DefaultContainerType>();
         using recv_value_type = typename std::remove_reference_t<decltype(recv_buf)>::value_type;
@@ -102,7 +102,7 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::allreduce(Args... 
         );
 
         // Get the send_recv_type.
-        auto&& send_recv_type = determine_mpi_send_recv_datatype<send_value_type, decltype(recv_buf)>(args...);
+        auto send_recv_type = determine_mpi_send_recv_datatype<send_value_type, decltype(recv_buf)>(args...);
         [[maybe_unused]] constexpr bool send_recv_type_is_in_param = !has_to_be_computed<decltype(send_recv_type)>;
 
         // Get the operation used for the reduction. The signature of the provided function is checked while building.
@@ -110,10 +110,10 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::allreduce(Args... 
         auto  operation       = operation_param.template build_operation<send_value_type>();
 
         using default_send_recv_count_type = decltype(kamping::send_recv_count_out());
-        auto&& send_recv_count             = internal::select_parameter_type_or_default<
-                                     internal::ParameterType::send_recv_count,
-                                     default_send_recv_count_type>({}, args...)
-                                     .construct_buffer_or_rebind();
+        auto send_recv_count               = internal::select_parameter_type_or_default<
+                                   internal::ParameterType::send_recv_count,
+                                   default_send_recv_count_type>({}, args...)
+                                   .construct_buffer_or_rebind();
         if constexpr (has_to_be_computed<decltype(send_recv_count)>) {
             send_recv_count.underlying() = asserting_cast<int>(send_buf.size());
         }
@@ -201,11 +201,11 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::allreduce_inplace(
     );
 
     // Get the send buffer and deduce the send and recv value types.
-    auto&& send_recv_buf = select_parameter_type<ParameterType::send_recv_buf>(args...).construct_buffer_or_rebind();
+    auto send_recv_buf = select_parameter_type<ParameterType::send_recv_buf>(args...).construct_buffer_or_rebind();
     using send_recv_value_type = typename std::remove_reference_t<decltype(send_recv_buf)>::value_type;
 
     // Get the send_recv_type.
-    auto&& send_recv_type = determine_mpi_send_recv_datatype<send_recv_value_type, decltype(send_recv_buf)>(args...);
+    auto send_recv_type = determine_mpi_send_recv_datatype<send_recv_value_type, decltype(send_recv_buf)>(args...);
     [[maybe_unused]] constexpr bool send_recv_type_is_in_param = !has_to_be_computed<decltype(send_recv_type)>;
 
     // Get the operation used for the reduction. The signature of the provided function is checked while building.
@@ -213,10 +213,10 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::allreduce_inplace(
     auto  operation       = operation_param.template build_operation<send_recv_value_type>();
 
     using default_send_recv_count_type = decltype(kamping::send_recv_count_out());
-    auto&& send_recv_count             = internal::select_parameter_type_or_default<
-                                 internal::ParameterType::send_recv_count,
-                                 default_send_recv_count_type>({}, args...)
-                                 .construct_buffer_or_rebind();
+    auto send_recv_count               = internal::select_parameter_type_or_default<
+                               internal::ParameterType::send_recv_count,
+                               default_send_recv_count_type>({}, args...)
+                               .construct_buffer_or_rebind();
     if constexpr (has_to_be_computed<decltype(send_recv_count)>) {
         send_recv_count.underlying() = asserting_cast<int>(send_recv_buf.size());
     }

--- a/include/kamping/collectives/bcast.hpp
+++ b/include/kamping/collectives/bcast.hpp
@@ -94,7 +94,7 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::bcast(Args... args
 
     using default_send_recv_buf_type =
         decltype(kamping::send_recv_buf(alloc_new<DefaultContainerType<recv_value_type_tparam>>));
-    auto&& send_recv_buf =
+    auto send_recv_buf =
         internal::select_parameter_type_or_default<internal::ParameterType::send_recv_buf, default_send_recv_buf_type>(
             std::tuple(),
             args...
@@ -118,7 +118,7 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::bcast(Args... args
 
     constexpr bool buffer_is_modifiable = std::remove_reference_t<decltype(send_recv_buf)>::is_modifiable;
 
-    auto&& send_recv_type = determine_mpi_send_recv_datatype<value_type, decltype(send_recv_buf)>(args...);
+    auto send_recv_type = determine_mpi_send_recv_datatype<value_type, decltype(send_recv_buf)>(args...);
     [[maybe_unused]] constexpr bool send_recv_type_is_in_param = !has_to_be_computed<decltype(send_recv_type)>;
 
     KASSERT(
@@ -129,11 +129,11 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::bcast(Args... args
 
     // Get the optional recv_count parameter. If the parameter is not given, allocate a new container.
     using default_count_type = decltype(kamping::send_recv_count_out());
-    auto&& count_param = internal::select_parameter_type_or_default<ParameterType::send_recv_count, default_count_type>(
-                             std::tuple(),
-                             args...
+    auto count_param = internal::select_parameter_type_or_default<ParameterType::send_recv_count, default_count_type>(
+                           std::tuple(),
+                           args...
     )
-                             .construct_buffer_or_rebind();
+                           .construct_buffer_or_rebind();
 
     constexpr bool count_has_to_be_computed = has_to_be_computed<decltype(count_param)>;
     KASSERT(

--- a/include/kamping/collectives/exscan.hpp
+++ b/include/kamping/collectives/exscan.hpp
@@ -94,7 +94,7 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::exscan(Args... arg
         );
 
         // Get the send buffer and deduce the send and recv value types.
-        auto const&& send_buf = select_parameter_type<ParameterType::send_buf>(args...).construct_buffer_or_rebind();
+        auto const send_buf   = select_parameter_type<ParameterType::send_buf>(args...).construct_buffer_or_rebind();
         using send_value_type = typename std::remove_reference_t<decltype(send_buf)>::value_type;
         KASSERT(
             is_same_on_all_ranks(send_buf.size()),
@@ -106,20 +106,20 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::exscan(Args... arg
         using default_recv_value_type = std::remove_const_t<send_value_type>;
         using default_recv_buf_type =
             decltype(kamping::recv_buf(alloc_new<DefaultContainerType<default_recv_value_type>>));
-        auto&& recv_buf =
+        auto recv_buf =
             select_parameter_type_or_default<ParameterType::recv_buf, default_recv_buf_type>(std::tuple(), args...)
                 .template construct_buffer_or_rebind<DefaultContainerType>();
 
         // Get the send_recv_type.
-        auto&& send_recv_type = determine_mpi_send_recv_datatype<send_value_type, decltype(recv_buf)>(args...);
+        auto send_recv_type = determine_mpi_send_recv_datatype<send_value_type, decltype(recv_buf)>(args...);
         [[maybe_unused]] constexpr bool send_recv_type_is_in_param = !has_to_be_computed<decltype(send_recv_type)>;
 
         // Get the send_recv count
         using default_send_recv_count_type = decltype(kamping::send_recv_count_out());
-        auto&& send_recv_count             = internal::select_parameter_type_or_default<
-                                     internal::ParameterType::send_recv_count,
-                                     default_send_recv_count_type>(std::tuple(), args...)
-                                     .construct_buffer_or_rebind();
+        auto send_recv_count               = internal::select_parameter_type_or_default<
+                                   internal::ParameterType::send_recv_count,
+                                   default_send_recv_count_type>(std::tuple(), args...)
+                                   .construct_buffer_or_rebind();
 
         constexpr bool do_compute_send_recv_count = internal::has_to_be_computed<decltype(send_recv_count)>;
         if constexpr (do_compute_send_recv_count) {
@@ -171,7 +171,7 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::exscan(Args... arg
             // auto-deduce the identity, as this would introduce a parameter which is required in some situtations in
             // KaMPIng, but never in MPI.
             if constexpr (has_values_on_rank_0_param) {
-                auto const& values_on_rank_0_param =
+                auto values_on_rank_0_param =
                     select_parameter_type<ParameterType::values_on_rank_0>(args...).construct_buffer_or_rebind();
                 KASSERT(
                     // if the send_recv type is user provided, kamping cannot make any assumptions about the required
@@ -253,16 +253,16 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::exscan_inplace(Arg
     );
 
     // get the send recv buffer and deduce the send and recv value types.
-    auto&& send_recv_buf = select_parameter_type<ParameterType::send_recv_buf>(args...).construct_buffer_or_rebind();
-    using value_type     = typename std::remove_reference_t<decltype(send_recv_buf)>::value_type;
+    auto send_recv_buf = select_parameter_type<ParameterType::send_recv_buf>(args...).construct_buffer_or_rebind();
+    using value_type   = typename std::remove_reference_t<decltype(send_recv_buf)>::value_type;
 
     // get the send_recv_type
-    auto&& type = determine_mpi_send_recv_datatype<value_type, decltype(send_recv_buf)>(args...);
+    auto type = determine_mpi_send_recv_datatype<value_type, decltype(send_recv_buf)>(args...);
     [[maybe_unused]] constexpr bool type_is_in_param = !has_to_be_computed<decltype(type)>;
 
     // get the send_recv count
     using default_count_type = decltype(kamping::send_recv_count_out());
-    auto&& count =
+    auto count =
         internal::select_parameter_type_or_default<internal::ParameterType::send_recv_count, default_count_type>(
             std::tuple(),
             args...
@@ -318,7 +318,7 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::exscan_inplace(Arg
         // auto-deduce the identity, as this would introduce a parameter which is required in some situtations in
         // KaMPIng, but never in MPI.
         if constexpr (has_values_on_rank_0_param) {
-            auto const& values_on_rank_0_param =
+            auto values_on_rank_0_param =
                 select_parameter_type<ParameterType::values_on_rank_0>(args...).construct_buffer_or_rebind();
             KASSERT(
                 // if the send_recv type is user provided, kamping cannot make any assumptions about the required

--- a/include/kamping/collectives/gather.hpp
+++ b/include/kamping/collectives/gather.hpp
@@ -96,12 +96,12 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::gather(Args... arg
         assert::light_communication
     );
 
-    auto&& send_buf =
+    auto send_buf =
         internal::select_parameter_type<internal::ParameterType::send_buf>(args...).construct_buffer_or_rebind();
     using send_value_type = typename std::remove_reference_t<decltype(send_buf)>::value_type;
 
     using default_send_count_type = decltype(kamping::send_count_out());
-    auto&& send_count =
+    auto send_count =
         internal::select_parameter_type_or_default<internal::ParameterType::send_count, default_send_count_type>(
             std::tuple(),
             args...
@@ -114,7 +114,7 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::gather(Args... arg
 
     using default_recv_buf_type = decltype(kamping::recv_buf(alloc_new<DefaultContainerType<send_value_type>>));
 
-    auto&& recv_buf =
+    auto recv_buf =
         internal::select_parameter_type_or_default<internal::ParameterType::recv_buf, default_recv_buf_type>(
             std::tuple(),
             args...
@@ -123,14 +123,14 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::gather(Args... arg
     using recv_value_type = typename std::remove_reference_t<decltype(recv_buf)>::value_type;
 
     // Get send_type and recv_type
-    auto&& [send_type, recv_type] =
+    auto [send_type, recv_type] =
         internal::determine_mpi_datatypes<send_value_type, recv_value_type, decltype(recv_buf)>(args...);
     [[maybe_unused]] constexpr bool recv_type_is_in_param = !has_to_be_computed<decltype(recv_type)>;
 
     // Optional parameter: recv_count()
     // Default: compute value based on send_buf.size on root
     using default_recv_count_type = decltype(kamping::recv_count_out());
-    auto&& recv_count =
+    auto recv_count =
         internal::select_parameter_type_or_default<internal::ParameterType::recv_count, default_recv_count_type>(
             std::tuple(),
             args...
@@ -228,13 +228,13 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::gatherv(Args... ar
     );
 
     // get send buffer
-    auto&& send_buf =
+    auto send_buf =
         internal::select_parameter_type<internal::ParameterType::send_buf>(args...).construct_buffer_or_rebind();
     using send_value_type = typename std::remove_reference_t<decltype(send_buf)>::value_type;
 
     // get recv buffer
     using default_recv_buf_type = decltype(kamping::recv_buf(alloc_new<DefaultContainerType<send_value_type>>));
-    auto&& recv_buf =
+    auto recv_buf =
         internal::select_parameter_type_or_default<internal::ParameterType::recv_buf, default_recv_buf_type>(
             std::tuple(),
             args...
@@ -249,13 +249,13 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::gatherv(Args... ar
     );
 
     // get send and recv type
-    auto&& [send_type, recv_type] =
+    auto [send_type, recv_type] =
         internal::determine_mpi_datatypes<send_value_type, recv_value_type, decltype(recv_buf)>(args...);
     [[maybe_unused]] constexpr bool recv_type_is_in_param = !has_to_be_computed<decltype(recv_type)>;
 
     // get recv counts
     using default_recv_counts_type = decltype(kamping::recv_counts_out(alloc_new<DefaultContainerType<int>>));
-    auto&& recv_counts =
+    auto recv_counts =
         internal::select_parameter_type_or_default<internal::ParameterType::recv_counts, default_recv_counts_type>(
             std::tuple(),
             args...
@@ -279,7 +279,7 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::gatherv(Args... ar
     );
 
     using default_send_count_type = decltype(kamping::send_count_out());
-    auto&& send_count =
+    auto send_count =
         internal::select_parameter_type_or_default<internal::ParameterType::send_count, default_send_count_type>(
             std::tuple(),
             args...
@@ -292,7 +292,7 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::gatherv(Args... ar
 
     // get recv displs
     using default_recv_displs_type = decltype(kamping::recv_displs_out(alloc_new<DefaultContainerType<int>>));
-    auto&& recv_displs =
+    auto recv_displs =
         internal::select_parameter_type_or_default<internal::ParameterType::recv_displs, default_recv_displs_type>(
             std::tuple(),
             args...

--- a/include/kamping/collectives/reduce.hpp
+++ b/include/kamping/collectives/reduce.hpp
@@ -88,13 +88,13 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::reduce(Args... arg
     );
 
     // Get the send buffer and deduce the send and recv value types.
-    auto const& send_buf =
+    auto const send_buf =
         internal::select_parameter_type<internal::ParameterType::send_buf>(args...).construct_buffer_or_rebind();
     using send_value_type         = typename std::remove_reference_t<decltype(send_buf)>::value_type;
     using default_recv_value_type = std::remove_const_t<send_value_type>;
 
     using default_recv_buf_type = decltype(kamping::recv_buf(alloc_new<DefaultContainerType<default_recv_value_type>>));
-    auto&& recv_buf =
+    auto recv_buf =
         internal::select_parameter_type_or_default<internal::ParameterType::recv_buf, default_recv_buf_type>(
             std::tuple(),
             args...
@@ -102,7 +102,7 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::reduce(Args... arg
             .template construct_buffer_or_rebind<DefaultContainerType>();
 
     // Get the send type.
-    auto&& send_recv_type = determine_mpi_send_recv_datatype<send_value_type, decltype(recv_buf)>(args...);
+    auto send_recv_type = determine_mpi_send_recv_datatype<send_value_type, decltype(recv_buf)>(args...);
     [[maybe_unused]] constexpr bool send_recv_type_is_in_param = !has_to_be_computed<decltype(send_recv_type)>;
 
     // Get the operation used for the reduction. The signature of the provided function is checked while building.
@@ -111,10 +111,10 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::reduce(Args... arg
     auto operation = operation_param.template build_operation<send_value_type>();
 
     using default_send_recv_count_type = decltype(kamping::send_recv_count_out());
-    auto&& send_recv_count             = internal::select_parameter_type_or_default<
-                                 internal::ParameterType::send_recv_count,
-                                 default_send_recv_count_type>({}, args...)
-                                 .construct_buffer_or_rebind();
+    auto send_recv_count               = internal::select_parameter_type_or_default<
+                               internal::ParameterType::send_recv_count,
+                               default_send_recv_count_type>({}, args...)
+                               .construct_buffer_or_rebind();
     if constexpr (has_to_be_computed<decltype(send_recv_count)>) {
         send_recv_count.underlying() = asserting_cast<int>(send_buf.size());
     }

--- a/include/kamping/collectives/scan.hpp
+++ b/include/kamping/collectives/scan.hpp
@@ -86,27 +86,27 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::scan(Args... args)
         );
 
         // get the send buffer and deduce the send and recv value types.
-        auto const&& send_buf = select_parameter_type<ParameterType::send_buf>(args...).construct_buffer_or_rebind();
+        auto const send_buf   = select_parameter_type<ParameterType::send_buf>(args...).construct_buffer_or_rebind();
         using send_value_type = typename std::remove_reference_t<decltype(send_buf)>::value_type;
         using default_recv_value_type = std::remove_const_t<send_value_type>;
 
         // deduce the recv buffer type and get (if provided) the recv buffer or allocate one (if not provided).
         using default_recv_buf_type =
             decltype(kamping::recv_buf(alloc_new<DefaultContainerType<default_recv_value_type>>));
-        auto&& recv_buf =
+        auto recv_buf =
             select_parameter_type_or_default<ParameterType::recv_buf, default_recv_buf_type>(std::tuple(), args...)
                 .template construct_buffer_or_rebind<DefaultContainerType>();
 
         // get the send_recv_type
-        auto&& send_recv_type = determine_mpi_send_recv_datatype<send_value_type, decltype(recv_buf)>(args...);
+        auto send_recv_type = determine_mpi_send_recv_datatype<send_value_type, decltype(recv_buf)>(args...);
         [[maybe_unused]] constexpr bool send_recv_type_is_in_param = !has_to_be_computed<decltype(send_recv_type)>;
 
         // get the send_recv count
         using default_send_recv_count_type = decltype(kamping::send_recv_count_out());
-        auto&& send_recv_count             = internal::select_parameter_type_or_default<
-                                     internal::ParameterType::send_recv_count,
-                                     default_send_recv_count_type>(std::tuple(), args...)
-                                     .construct_buffer_or_rebind();
+        auto send_recv_count               = internal::select_parameter_type_or_default<
+                                   internal::ParameterType::send_recv_count,
+                                   default_send_recv_count_type>(std::tuple(), args...)
+                                   .construct_buffer_or_rebind();
 
         constexpr bool do_compute_send_recv_count = internal::has_to_be_computed<decltype(send_recv_count)>;
         if constexpr (do_compute_send_recv_count) {
@@ -196,16 +196,16 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::scan_inplace(Args.
     );
 
     // get the send recv buffer and deduce the send and recv value types.
-    auto&& send_recv_buf = select_parameter_type<ParameterType::send_recv_buf>(args...).construct_buffer_or_rebind();
-    using value_type     = typename std::remove_reference_t<decltype(send_recv_buf)>::value_type;
+    auto send_recv_buf = select_parameter_type<ParameterType::send_recv_buf>(args...).construct_buffer_or_rebind();
+    using value_type   = typename std::remove_reference_t<decltype(send_recv_buf)>::value_type;
 
     // get the send_recv_type
-    auto&& type = determine_mpi_send_recv_datatype<value_type, decltype(send_recv_buf)>(args...);
+    auto type = determine_mpi_send_recv_datatype<value_type, decltype(send_recv_buf)>(args...);
     [[maybe_unused]] constexpr bool type_is_in_param = !has_to_be_computed<decltype(type)>;
 
     // get the send_recv count
     using default_count_type = decltype(kamping::send_recv_count_out());
-    auto&& count =
+    auto count =
         internal::select_parameter_type_or_default<internal::ParameterType::send_recv_count, default_count_type>(
             std::tuple(),
             args...

--- a/include/kamping/collectives/scatter.hpp
+++ b/include/kamping/collectives/scatter.hpp
@@ -116,7 +116,7 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::scatter(Args... ar
     // Optional parameter: recv_buf()
     // Default: allocate new container
     using default_recv_buf_type = decltype(kamping::recv_buf(alloc_new<DefaultContainerType<send_value_type>>));
-    auto&& recv_buf =
+    auto recv_buf =
         internal::select_parameter_type_or_default<internal::ParameterType::recv_buf, default_recv_buf_type>(
             std::tuple(),
             args...
@@ -131,7 +131,7 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::scatter(Args... ar
     );
 
     // Get send_type and recv_type
-    auto&& [send_type, recv_type] =
+    auto [send_type, recv_type] =
         internal::determine_mpi_datatypes<send_value_type, recv_value_type, decltype(recv_buf)>(args...);
     KASSERT(
         !is_root(int_root) || send_type.underlying() != MPI_DATATYPE_NULL,
@@ -142,7 +142,7 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::scatter(Args... ar
 
     // Compute sendcount based on the size of the sendbuf
     using default_send_count_type = decltype(kamping::send_count_out());
-    auto&& send_count =
+    auto send_count =
         internal::select_parameter_type_or_default<internal::ParameterType::send_count, default_send_count_type>(
             std::tuple(),
             args...
@@ -165,7 +165,7 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::scatter(Args... ar
     // Optional parameter: recv_count()
     // Default: compute value based on send_buf.size on root
     using default_recv_count_type = decltype(kamping::recv_count_out());
-    auto&& recv_count =
+    auto recv_count =
         internal::select_parameter_type_or_default<internal::ParameterType::recv_count, default_recv_count_type>(
             std::tuple(),
             args...
@@ -368,7 +368,7 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::scatterv(Args... a
     // Optional parameter: recv_buf()
     // Default: allocate new container
     using default_recv_buf_type = decltype(kamping::recv_buf(alloc_new<DefaultContainerType<send_value_type>>));
-    auto&& recv_buf =
+    auto recv_buf =
         internal::select_parameter_type_or_default<internal::ParameterType::recv_buf, default_recv_buf_type>(
             std::tuple(),
             args...
@@ -383,13 +383,13 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::scatterv(Args... a
     );
 
     // Get send_type and recv_type
-    auto&& [send_type, recv_type] =
+    auto [send_type, recv_type] =
         internal::determine_mpi_datatypes<send_value_type, recv_value_type, decltype(recv_buf)>(args...);
     [[maybe_unused]] constexpr bool recv_type_is_in_param = !has_to_be_computed<decltype(recv_type)>;
 
     // Get send counts
     using default_send_counts_type = decltype(send_counts_out(alloc_new<DefaultContainerType<int>>));
-    auto&& send_counts =
+    auto send_counts =
         select_parameter_type_or_default<ParameterType::send_counts, default_send_counts_type>(std::tuple(), args...)
             .template construct_buffer_or_rebind<DefaultContainerType>();
     [[maybe_unused]] constexpr bool send_counts_provided = !has_to_be_computed<decltype(send_counts)>;
@@ -406,7 +406,7 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::scatterv(Args... a
 
     // Get send displacements
     using default_send_displs_type = decltype(send_displs_out(alloc_new<DefaultContainerType<int>>));
-    auto&& send_displs =
+    auto send_displs =
         select_parameter_type_or_default<ParameterType::send_displs, default_send_displs_type>(std::tuple(), args...)
             .template construct_buffer_or_rebind<DefaultContainerType>();
 
@@ -429,7 +429,7 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::scatterv(Args... a
 
     // Get recv counts
     using default_recv_count_type = decltype(recv_count_out());
-    auto&& recv_count =
+    auto recv_count =
         select_parameter_type_or_default<ParameterType::recv_count, default_recv_count_type>(std::tuple(), args...)
             .construct_buffer_or_rebind();
 

--- a/include/kamping/p2p/helpers.hpp
+++ b/include/kamping/p2p/helpers.hpp
@@ -46,10 +46,7 @@ constexpr auto determine_mpi_send_datatype(Args&... args)
     // Get the send type
     using default_mpi_send_type = decltype(kamping::send_type_out());
 
-    // decltype(auto) becomes an lvalue reference type if the initializer is an lvalue and a non-reference type if the
-    // the initializer is a pr-value (e.g. a function call returning by value). These are the only two value categories
-    // we accept for the return value of select_parameter_type_or_default.
-    decltype(auto) mpi_send_type =
+    auto mpi_send_type =
         internal::select_parameter_type_or_default<internal::ParameterType::send_type, default_mpi_send_type>(
             std::make_tuple(),
             args...
@@ -93,10 +90,7 @@ constexpr auto determine_mpi_recv_datatype(Args&... args)
     // Get the recv type
     using default_mpi_recv_type = decltype(kamping::recv_type_out());
 
-    // decltype(auto) becomes an lvalue reference type if the initializer is an lvalue and a non-reference type if the
-    // the initializer is a pr-value (e.g. a function call returning by value). These are the only two value categories
-    // we accept for the return value of select_parameter_type_or_default.
-    decltype(auto) mpi_recv_type =
+    auto mpi_recv_type =
         internal::select_parameter_type_or_default<internal::ParameterType::recv_type, default_mpi_recv_type>(
             std::make_tuple(),
             args...

--- a/include/kamping/p2p/iprobe.hpp
+++ b/include/kamping/p2p/iprobe.hpp
@@ -20,7 +20,6 @@
 #include <mpi.h>
 
 #include "kamping/communicator.hpp"
-#include "kamping/data_buffer.hpp"
 #include "kamping/implementation_helpers.hpp"
 #include "kamping/named_parameter_check.hpp"
 #include "kamping/named_parameter_selection.hpp"
@@ -85,7 +84,7 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::iprobe(Args... arg
 
     using default_status_param_type = decltype(kamping::status(kamping::ignore<>));
 
-    auto&& status =
+    auto status =
         internal::select_parameter_type_or_default<internal::ParameterType::status, default_status_param_type>(
             {},
             args...

--- a/include/kamping/p2p/irecv.hpp
+++ b/include/kamping/p2p/irecv.hpp
@@ -23,9 +23,7 @@
 
 #include "kamping/communicator.hpp"
 #include "kamping/data_buffer.hpp"
-#include "kamping/error_handling.hpp"
 #include "kamping/implementation_helpers.hpp"
-#include "kamping/mpi_datatype.hpp"
 #include "kamping/named_parameter_check.hpp"
 #include "kamping/named_parameter_selection.hpp"
 #include "kamping/named_parameter_types.hpp"
@@ -33,7 +31,6 @@
 #include "kamping/p2p/helpers.hpp"
 #include "kamping/p2p/probe.hpp"
 #include "kamping/parameter_objects.hpp"
-#include "kamping/request.hpp"
 #include "kamping/result.hpp"
 #include "kamping/status.hpp"
 
@@ -89,7 +86,7 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::irecv(Args... args
         KAMPING_OPTIONAL_PARAMETERS(recv_buf, tag, source, recv_count, recv_type, request)
     );
     using default_recv_buf_type = decltype(kamping::recv_buf(alloc_new<DefaultContainerType<recv_value_type_tparam>>));
-    auto&& recv_buf =
+    auto recv_buf =
         internal::select_parameter_type_or_default<internal::ParameterType::recv_buf, default_recv_buf_type>(
             std::tuple(),
             args...
@@ -101,7 +98,7 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::irecv(Args... args
         "No recv_buf parameter provided and no receive value given as template parameter. One of these is required."
     );
 
-    auto&& recv_type = internal::determine_mpi_recv_datatype<recv_value_type, decltype(recv_buf)>(args...);
+    auto recv_type = internal::determine_mpi_recv_datatype<recv_value_type, decltype(recv_buf)>(args...);
     [[maybe_unused]] constexpr bool recv_type_is_in_param = !internal::has_to_be_computed<decltype(recv_type)>;
 
     using default_request_param = decltype(kamping::request());
@@ -136,7 +133,7 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::irecv(Args... args
     // Get the optional recv_count parameter. If the parameter is not given,
     // allocate a new container.
     using default_recv_count_type = decltype(kamping::recv_count_out());
-    auto&& recv_count_param =
+    auto recv_count_param =
         internal::select_parameter_type_or_default<internal::ParameterType::recv_count, default_recv_count_type>(
             std::tuple(),
             args...

--- a/include/kamping/p2p/isend.hpp
+++ b/include/kamping/p2p/isend.hpp
@@ -21,16 +21,13 @@
 #include <mpi.h>
 
 #include "kamping/communicator.hpp"
-#include "kamping/data_buffer.hpp"
 #include "kamping/implementation_helpers.hpp"
-#include "kamping/mpi_datatype.hpp"
 #include "kamping/named_parameter_check.hpp"
 #include "kamping/named_parameter_selection.hpp"
 #include "kamping/named_parameter_types.hpp"
 #include "kamping/named_parameters.hpp"
 #include "kamping/p2p/helpers.hpp"
 #include "kamping/parameter_objects.hpp"
-#include "kamping/request.hpp"
 #include "kamping/result.hpp"
 
 ///// @addtogroup kamping_p2p
@@ -85,14 +82,14 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::isend(Args... args
         KAMPING_OPTIONAL_PARAMETERS(send_count, tag, send_mode, request, send_type)
     );
 
-    auto&& send_buf =
+    auto send_buf =
         internal::select_parameter_type<internal::ParameterType::send_buf>(args...).construct_buffer_or_rebind();
     using send_value_type = typename std::remove_reference_t<decltype(send_buf)>::value_type;
 
-    auto&& send_type = internal::determine_mpi_send_datatype<send_value_type>(args...);
+    auto send_type = internal::determine_mpi_send_datatype<send_value_type>(args...);
 
     using default_send_count_type = decltype(kamping::send_count_out());
-    auto&& send_count =
+    auto send_count =
         internal::select_parameter_type_or_default<internal::ParameterType::send_count, default_send_count_type>(
             {},
             args...

--- a/include/kamping/p2p/probe.hpp
+++ b/include/kamping/p2p/probe.hpp
@@ -20,7 +20,6 @@
 #include <mpi.h>
 
 #include "kamping/communicator.hpp"
-#include "kamping/data_buffer.hpp"
 #include "kamping/implementation_helpers.hpp"
 #include "kamping/named_parameter_check.hpp"
 #include "kamping/named_parameter_selection.hpp"
@@ -82,7 +81,7 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::probe(Args... args
 
     using default_status_param_type = decltype(kamping::status(kamping::ignore<>));
 
-    auto&& status =
+    auto status =
         internal::select_parameter_type_or_default<internal::ParameterType::status, default_status_param_type>(
             {},
             args...

--- a/include/kamping/p2p/recv.hpp
+++ b/include/kamping/p2p/recv.hpp
@@ -23,9 +23,7 @@
 
 #include "kamping/communicator.hpp"
 #include "kamping/data_buffer.hpp"
-#include "kamping/error_handling.hpp"
 #include "kamping/implementation_helpers.hpp"
-#include "kamping/mpi_datatype.hpp"
 #include "kamping/named_parameter_check.hpp"
 #include "kamping/named_parameter_selection.hpp"
 #include "kamping/named_parameter_types.hpp"
@@ -88,7 +86,7 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::recv(Args... args)
         KAMPING_OPTIONAL_PARAMETERS(recv_buf, tag, source, recv_count, recv_type, status)
     );
     using default_recv_buf_type = decltype(kamping::recv_buf(alloc_new<DefaultContainerType<recv_value_type_tparam>>));
-    auto&& recv_buf =
+    auto recv_buf =
         internal::select_parameter_type_or_default<internal::ParameterType::recv_buf, default_recv_buf_type>(
             std::tuple(),
             args...
@@ -105,7 +103,7 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::recv(Args... args)
         "No recv_buf parameter provided and no receive value given as template parameter. One of these is required."
     );
 
-    auto&& recv_type = internal::determine_mpi_recv_datatype<recv_value_type, decltype(recv_buf)>(args...);
+    auto recv_type = internal::determine_mpi_recv_datatype<recv_value_type, decltype(recv_buf)>(args...);
     [[maybe_unused]] constexpr bool recv_type_is_in_param = !internal::has_to_be_computed<decltype(recv_type)>;
 
     using default_source_buf_type = decltype(kamping::source(rank::any));
@@ -132,7 +130,7 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::recv(Args... args)
 
     using default_status_param_type = decltype(kamping::status(kamping::ignore<>));
 
-    auto&& status =
+    auto status =
         internal::select_parameter_type_or_default<internal::ParameterType::status, default_status_param_type>(
             {},
             args...
@@ -142,7 +140,7 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::recv(Args... args)
     // Get the optional recv_count parameter. If the parameter is not given,
     // allocate a new container.
     using default_recv_count_type = decltype(kamping::recv_count_out());
-    auto&& recv_count_param =
+    auto recv_count_param =
         internal::select_parameter_type_or_default<internal::ParameterType::recv_count, default_recv_count_type>(
             std::tuple(),
             args...

--- a/include/kamping/p2p/send.hpp
+++ b/include/kamping/p2p/send.hpp
@@ -21,9 +21,7 @@
 #include <mpi.h>
 
 #include "kamping/communicator.hpp"
-#include "kamping/data_buffer.hpp"
 #include "kamping/implementation_helpers.hpp"
-#include "kamping/mpi_datatype.hpp"
 #include "kamping/named_parameter_check.hpp"
 #include "kamping/named_parameter_selection.hpp"
 #include "kamping/named_parameter_types.hpp"
@@ -73,8 +71,8 @@ void kamping::Communicator<DefaultContainerType, Plugins...>::send(Args... args)
         KAMPING_OPTIONAL_PARAMETERS(send_count, tag, send_mode, send_type)
     );
 
-    auto&& send_buf = internal::select_parameter_type<internal::ParameterType::send_buf>(args...)
-                          .template construct_buffer_or_rebind<UnusedRebindContainer, serialization_support_tag>();
+    auto send_buf = internal::select_parameter_type<internal::ParameterType::send_buf>(args...)
+                        .template construct_buffer_or_rebind<UnusedRebindContainer, serialization_support_tag>();
     constexpr bool is_serialization_used = internal::buffer_uses_serialization<decltype(send_buf)>;
     if constexpr (is_serialization_used) {
         KAMPING_UNSUPPORTED_PARAMETER(Args, send_count, when using serialization);
@@ -83,10 +81,10 @@ void kamping::Communicator<DefaultContainerType, Plugins...>::send(Args... args)
     }
     using send_value_type = typename std::remove_reference_t<decltype(send_buf)>::value_type;
 
-    auto&& send_type = internal::determine_mpi_send_datatype<send_value_type>(args...);
+    auto send_type = internal::determine_mpi_send_datatype<send_value_type>(args...);
 
     using default_send_count_type = decltype(kamping::send_count_out());
-    auto&& send_count =
+    auto send_count =
         internal::select_parameter_type_or_default<internal::ParameterType::send_count, default_send_count_type>(
             {},
             args...

--- a/include/kamping/p2p/try_recv.hpp
+++ b/include/kamping/p2p/try_recv.hpp
@@ -23,7 +23,6 @@
 
 #include "kamping/communicator.hpp"
 #include "kamping/data_buffer.hpp"
-#include "kamping/error_handling.hpp"
 #include "kamping/implementation_helpers.hpp"
 #include "kamping/named_parameter_check.hpp"
 #include "kamping/named_parameter_selection.hpp"
@@ -87,7 +86,7 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::try_recv(Args... a
 
     //  Get the recv buffer
     using default_recv_buf_type = decltype(kamping::recv_buf(alloc_new<DefaultContainerType<recv_value_type_tparam>>));
-    auto&& recv_buf =
+    auto recv_buf =
         internal::select_parameter_type_or_default<internal::ParameterType::recv_buf, default_recv_buf_type>(
             std::tuple(),
             args...
@@ -99,7 +98,7 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::try_recv(Args... a
         "No recv_buf parameter provided and no receive value given as template parameter. One of these is required."
     );
 
-    auto&& recv_type = internal::determine_mpi_recv_datatype<recv_value_type, decltype(recv_buf)>(args...);
+    auto recv_type = internal::determine_mpi_recv_datatype<recv_value_type, decltype(recv_buf)>(args...);
     [[maybe_unused]] constexpr bool recv_type_is_in_param = !internal::has_to_be_computed<decltype(recv_type)>;
 
     // Get the source parameter. If the parameter is not given, use MPI_ANY_SOURCE.
@@ -124,7 +123,7 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::try_recv(Args... a
     }
     // Get the status parameter.
     using default_status_param_type = decltype(kamping::status(kamping::ignore<>));
-    auto&& status_param =
+    auto status_param =
         internal::select_parameter_type_or_default<internal::ParameterType::status, default_status_param_type>(
             {},
             args...


### PR DESCRIPTION
This seems to be a false positive, but we can get rid of most of the `auto&&` because `construct_buffer_or_rebind` always returns a value. This also silences the warning.