### PR TITLE
Feature/sendrecv

### DIFF
--- a/examples/usage/CMakeLists.txt
+++ b/examples/usage/CMakeLists.txt
@@ -50,6 +50,10 @@ add_executable(example_datatype datatype_example.cpp)
 target_link_libraries(example_datatype kamping)
 target_compile_options(example_datatype PRIVATE ${KAMPING_WARNING_FLAGS})
 
+add_executable(example_sendrecv sendrecv_example.cpp)
+target_link_libraries(example_sendrecv kamping)
+target_compile_options(example_sendrecv PRIVATE ${KAMPING_WARNING_FLAGS})
+
 if (KAMPING_ENABLE_SERIALIZATION)
     add_executable(example_serialization serialization_example.cpp)
     target_link_libraries(example_serialization kamping cereal::cereal)

--- a/examples/usage/sendrecv_example.cpp
+++ b/examples/usage/sendrecv_example.cpp
@@ -1,8 +1,8 @@
 // This file is part of KaMPI.ng.
 //
-// Copyright 2024 The KaMPI.ng Authors
+// Copyright 2025 The KaMPIng Authors
 //
-// KaMPI.ng is free software : you can redistribute it and/or modify it under the terms of the GNU Lesser General Public
+// KaMPIng is free software : you can redistribute it and/or modify it under the terms of the GNU Lesser General Public
 // License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
 // version. KaMPI.ng is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
 // implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License

--- a/examples/usage/sendrecv_example.cpp
+++ b/examples/usage/sendrecv_example.cpp
@@ -1,0 +1,59 @@
+// This file is part of KaMPI.ng.
+//
+// Copyright 2024 The KaMPI.ng Authors
+//
+// KaMPI.ng is free software : you can redistribute it and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
+// version. KaMPI.ng is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+// implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+// for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along with KaMPI.ng.  If not, see
+// <https://www.gnu.org/licenses/>.
+
+#include <iostream>
+
+#include "kamping/p2p/sendrecv.hpp"
+#include "kamping/p2p/recv.hpp"
+#include "kamping/p2p/send.hpp"
+#include "helpers_for_examples.hpp"
+#include "kamping/checking_casts.hpp"
+#include "kamping/communicator.hpp"
+#include "kamping/data_buffer.hpp"
+#include "kamping/environment.hpp"
+#include "kamping/named_parameters.hpp"
+#include "kamping/collectives/barrier.hpp"
+
+
+int main() {
+    using namespace kamping;
+
+    kamping::Environment  e;
+    kamping::Communicator comm;
+
+    std::vector<int> input(1, comm.rank_signed());
+    std::vector<int> message;
+    auto dest = comm.rank_shifted_cyclic(1);
+
+    {
+        // Cyclic sendrecv given a recv buffer
+        comm.sendrecv(send_buf(input)
+                          , destination(dest)
+                          , recv_count(1)
+                          , recv_buf<kamping::BufferResizePolicy::resize_to_fit>(message));
+        std::cout << "Rank: " << comm.rank_signed() << " Received: " << message[0] << "\n";
+    }
+    comm.barrier();
+    print_on_root("------", comm);
+
+    {
+        // Cyclic sendrecv without an explicit recv buffer
+        auto received = comm.sendrecv<int>(send_buf(input)
+                          , destination(dest)
+                          , recv_count(1));
+        std::cout << "Rank: " << comm.rank_signed() << " Received: " << received[0] << "\n";
+    }
+
+
+
+}

--- a/examples/usage/sendrecv_example.cpp
+++ b/examples/usage/sendrecv_example.cpp
@@ -13,17 +13,16 @@
 
 #include <iostream>
 
-#include "kamping/p2p/sendrecv.hpp"
-#include "kamping/p2p/recv.hpp"
-#include "kamping/p2p/send.hpp"
 #include "helpers_for_examples.hpp"
 #include "kamping/checking_casts.hpp"
+#include "kamping/collectives/barrier.hpp"
 #include "kamping/communicator.hpp"
 #include "kamping/data_buffer.hpp"
 #include "kamping/environment.hpp"
 #include "kamping/named_parameters.hpp"
-#include "kamping/collectives/barrier.hpp"
-
+#include "kamping/p2p/recv.hpp"
+#include "kamping/p2p/send.hpp"
+#include "kamping/p2p/sendrecv.hpp"
 
 int main() {
     using namespace kamping;
@@ -33,14 +32,15 @@ int main() {
 
     std::vector<int> input(1, comm.rank_signed());
     std::vector<int> message;
-    auto dest = comm.rank_shifted_cyclic(1);
+    auto             dest = comm.rank_shifted_cyclic(1);
 
     {
         // Cyclic sendrecv given a recv buffer
-        comm.sendrecv(send_buf(input)
-                          , destination(dest)
-                          , recv_count(1)
-                          , recv_buf<kamping::BufferResizePolicy::resize_to_fit>(message));
+        comm.sendrecv(
+            send_buf(input),
+            destination(dest),
+            recv_buf<kamping::BufferResizePolicy::resize_to_fit>(message)
+        );
         std::cout << "Rank: " << comm.rank_signed() << " Received: " << message[0] << "\n";
     }
     comm.barrier();
@@ -48,12 +48,7 @@ int main() {
 
     {
         // Cyclic sendrecv without an explicit recv buffer
-        auto received = comm.sendrecv<int>(send_buf(input)
-                          , destination(dest)
-                          , recv_count(1));
+        auto received = comm.sendrecv<int>(send_buf(input), destination(dest));
         std::cout << "Rank: " << comm.rank_signed() << " Received: " << received[0] << "\n";
     }
-
-
-
 }

--- a/include/kamping/communicator.hpp
+++ b/include/kamping/communicator.hpp
@@ -494,6 +494,9 @@ public:
     auto iprobe(Args... args) const;
 
     template <typename recv_value_type_tparam = kamping::internal::unused_tparam, typename... Args>
+    auto sendrecv(Args... args) const;
+
+    template <typename recv_value_type_tparam = kamping::internal::unused_tparam, typename... Args>
     auto recv(Args... args) const;
 
     template <typename recv_value_type_tparam, typename... Args>

--- a/include/kamping/p2p/sendrecv.hpp
+++ b/include/kamping/p2p/sendrecv.hpp
@@ -155,6 +155,11 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::sendrecv(Args... a
         )
             .template construct_buffer_or_rebind<DefaultContainerType, internal::serialization_support_tag>();
 
+    KASSERT(
+        !(send_buf.size() == recv_buf.size() && send_buf.data() == recv_buf.data()),
+        "Send buffer and recv buffer can not be the same."
+    );
+
 
     auto recv_count_param = internal::select_parameter_type<internal::ParameterType::recv_count>(args...)
         .template construct_buffer_or_rebind<UnusedRebindContainer, serialization_support_tag>();
@@ -236,7 +241,7 @@ auto kamping::Communicator<DefaultContainerType, Plugins...>::sendrecv(Args... a
         source,                                         // source
         recv_tag,                                       // recv_tag
         this->mpi_communicator(),                       // comm
-        internal::status_param_to_native_ptr(status)   // status
+        internal::status_param_to_native_ptr(status)    // status
     );
     this->mpi_error_hook(err, "MPI_Sendrecv");
 

--- a/include/kamping/p2p/sendrecv.hpp
+++ b/include/kamping/p2p/sendrecv.hpp
@@ -1,0 +1,267 @@
+// This file is part of KaMPIng.
+//
+// Copyright 2022-2024 The KaMPIng Authors
+//
+// KaMPIng is free software : you can redistribute it and/or modify it under the
+// terms of the GNU Lesser General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option) any
+// later version. KaMPIng is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+// for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with KaMPIng.  If not, see <https://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <type_traits>
+#include <utility>
+
+#include <kassert/kassert.hpp>
+#include <mpi.h>
+
+#include "kamping/communicator.hpp"
+#include "kamping/data_buffer.hpp"
+#include "kamping/implementation_helpers.hpp"
+#include "kamping/named_parameter_check.hpp"
+#include "kamping/named_parameter_selection.hpp"
+#include "kamping/named_parameter_types.hpp"
+#include "kamping/named_parameters.hpp"
+#include "kamping/p2p/helpers.hpp"
+#include "kamping/p2p/probe.hpp"
+#include "kamping/parameter_objects.hpp"
+#include "kamping/result.hpp"
+#include "kamping/status.hpp"
+
+
+///// @addtogroup kamping_p2p
+/// @{
+
+// @brief Wrapper for \c MPI_Sendrecv.
+///
+/// This wraps \c MPI_Sendrecv. This operation performs a blocking send and receive operation. If the
+/// \ref kamping::recv_counts() parameter is not specified, this first performs a probe, followed by a receive of
+/// the probed message with the probed message size.
+///
+/// The following parameters are required:
+/// - \ref kamping::send_buf() containing the data that is sent.
+///
+///
+/// - \ref kamping::destination() the receiving rank.
+///
+/// The following parameter is optional, but leads to an additional call to \c MPI_Probe if not present:
+/// - \ref kamping::recv_count() the number of elements to receive. Will be probed before receiving if not given.
+///
+/// The following parameters are optional:
+/// - \ref kamping::recv_buf() the buffer to receive the message into.  The buffer's underlying
+/// storage must be large enough to hold all received elements. If no \ref kamping::recv_buf() is provided, the \c
+/// value_type of the recv buffer has to be passed as a template parameter to \c sendrecv().
+///
+///
+///
+/// - \ref kamping::send_count() specifying how many elements of the buffer are sent. If omitted, the size of the send
+/// buffer is used as a default.
+///
+/// - \ref kamping::source() receive a message sent from this source rank. Defaults to probing for an arbitrary source,
+/// i.e. \c source(rank::any).
+///
+/// - \ref kamping::send_tag() send message with this tag. Defaults to sending for an arbitrary tag, i.e. \c
+/// tag(tags::any).
+///
+/// - \ref kamping::recv_tag() receive message with this tag. Defaults to receiving for an arbitrary tag, i.e. \c
+/// tag(tags::any).
+///
+/// - \c kamping::status(ignore<>) or \ref kamping::status_out(). Returns info about the received message by setting the
+/// appropriate fields in the status object passed by the user. If \ref kamping::status_out() is passed, constructs a
+/// status object which may be retrieved by the user. The status can be ignored by passing \c
+/// kamping::status(kamping::ignore<>). This is the default.
+///
+/// @tparam Args Automatically deduced template parameters.
+/// @tparam recv_value_type_tparam The type of the message to be received.
+/// @param args All required and any number of the optional parameters described above.
+/// @return Result object wrapping the output parameters to be returned by value.
+///
+/// @see \ref docs/parameter_handling.md for general information about parameter handling in KaMPIng.
+/// <hr>
+
+
+template <
+    template <typename...>
+    typename DefaultContainerType,
+    template <typename, template <typename...> typename>
+    typename... Plugins>
+template <typename recv_value_type_tparam /* = kamping::internal::unused_tparam */, typename... Args>
+auto kamping::Communicator<DefaultContainerType, Plugins...>::sendrecv(Args... args) const {
+    using namespace kamping::internal;
+    KAMPING_CHECK_PARAMETERS(
+        Args,
+        KAMPING_REQUIRED_PARAMETERS(send_buf, destination),
+        KAMPING_OPTIONAL_PARAMETERS(send_count, send_type, send_tag, recv_buf, recv_tag, source, recv_count, recv_type
+                                    , status)
+    );
+
+    auto send_buf = internal::select_parameter_type<internal::ParameterType::send_buf>(args...)
+                        .template construct_buffer_or_rebind<UnusedRebindContainer, serialization_support_tag>();
+
+
+    constexpr bool is_send_serialization_used = internal::buffer_uses_serialization<decltype(send_buf)>;
+    if constexpr (is_send_serialization_used) {
+        KAMPING_UNSUPPORTED_PARAMETER(Args, send_count, when using serialization);
+        KAMPING_UNSUPPORTED_PARAMETER(Args, send_type, when using serialization);
+        send_buf.underlying().serialize();
+    }
+
+    using default_send_count_type = decltype(kamping::send_count_out());
+    auto send_count =
+        internal::select_parameter_type_or_default<internal::ParameterType::send_count, default_send_count_type>(
+            {},
+            args...
+        )
+            .construct_buffer_or_rebind();
+    if constexpr (has_to_be_computed<decltype(send_count)>) {
+        send_count.underlying() = asserting_cast<int>(send_buf.size());
+    }
+
+    using send_value_type = typename std::remove_reference_t<decltype(send_buf)>::value_type;
+    auto send_type = internal::determine_mpi_send_datatype<send_value_type>(args...);
+
+    auto const&    destination = internal::select_parameter_type<internal::ParameterType::destination>(args...);
+    constexpr auto rank_type   = std::remove_reference_t<decltype(destination)>::rank_type;
+    static_assert(
+        rank_type == RankType::value || rank_type == RankType::null,
+        "Please provide an explicit destination or destination(ranks::null)."
+    );
+
+    using default_tag_buf_type = decltype(kamping::tag(this->default_tag()));
+    auto&& send_tag_param = internal::select_parameter_type_or_default<internal::ParameterType::send_tag, default_tag_buf_type>(
+        std::tuple(this->default_tag()),
+        args...
+    );
+
+    // this ensures that the user does not try to pass MPI_ANY_TAG, which is not allowed for the send tag
+    static_assert(
+        std::remove_reference_t<decltype(send_tag_param)>::tag_type == TagType::value,
+        "Please provide a send tag for the message."
+    );
+    int send_tag = send_tag_param.tag();
+    KASSERT(
+        Environment<>::is_valid_tag(send_tag),
+        "invalid send tag " << send_tag << ", must be in range [0, " << Environment<>::tag_upper_bound() << "]"
+    );
+
+    using default_recv_buf_type = decltype(kamping::recv_buf(alloc_new<DefaultContainerType<recv_value_type_tparam>>));
+    auto recv_buf =
+        internal::select_parameter_type_or_default<internal::ParameterType::recv_buf, default_recv_buf_type>(
+            std::tuple(),
+            args...
+        )
+            .template construct_buffer_or_rebind<DefaultContainerType, internal::serialization_support_tag>();
+
+
+    // Get the optional recv_count parameter. If the parameter is not given,
+    // allocate a new container.
+    using default_recv_count_type = decltype(kamping::recv_count_out());
+    auto recv_count_param =
+        internal::select_parameter_type_or_default<internal::ParameterType::recv_count, default_recv_count_type>(
+            std::tuple(),
+            args...
+        )
+            .construct_buffer_or_rebind();
+
+
+    constexpr bool is_recv_serialization_used = internal::buffer_uses_serialization<decltype(recv_buf)>;
+    if constexpr (is_recv_serialization_used) {
+        KAMPING_UNSUPPORTED_PARAMETER(Args, recv_count, when using serialization);
+        KAMPING_UNSUPPORTED_PARAMETER(Args, recv_type, when using serialization);
+    }
+
+
+    using recv_value_type = typename std::remove_reference_t<decltype(recv_buf)>::value_type;
+    static_assert(
+        !std::is_same_v<recv_value_type, internal::unused_tparam>,
+        "No recv_buf parameter provided and no receive value given as template parameter. One of these is required."
+    );
+    auto recv_type = internal::determine_mpi_recv_datatype<recv_value_type, decltype(recv_buf)>(args...);
+    [[maybe_unused]] constexpr bool recv_type_is_in_param = !internal::has_to_be_computed<decltype(recv_type)>;
+
+
+    auto&& recv_tag_param =
+        internal::select_parameter_type_or_default<internal::ParameterType::recv_tag, default_tag_buf_type>({}, args...);
+    constexpr auto tag_type = std::remove_reference_t<decltype(recv_tag_param)>::tag_type;
+    if constexpr (tag_type == internal::TagType::value) {
+        int recv_tag = recv_tag_param.tag();
+        KASSERT(
+            Environment<>::is_valid_tag(recv_tag),
+            "invalid recv tag " << recv_tag << ", must be in range [0, " << Environment<>::tag_upper_bound() << "]"
+        );
+    }
+
+    using default_status_param_type = decltype(kamping::status(kamping::ignore<>));
+    auto status =
+        internal::select_parameter_type_or_default<internal::ParameterType::status, default_status_param_type>(
+            {},
+            args...
+        )
+            .construct_buffer_or_rebind();
+
+    using default_source_buf_type = decltype(kamping::source(rank::any));
+    auto&& source_param =
+        internal::select_parameter_type_or_default<internal::ParameterType::source, default_source_buf_type>(
+            {},
+            args...
+        );
+
+
+    KASSERT(internal::is_valid_rank_in_comm(source_param, *this, true, true));
+    int source = source_param.rank_signed();
+    int recv_tag    = recv_tag_param.tag();
+    // If the recv count needs to be computed a probe is executed
+    if constexpr (internal::has_to_be_computed<decltype(recv_count_param)>) {
+        Status probe_status = this->probe(source_param.clone(), recv_tag_param.clone(), status_out()).extract_status();
+        source              = probe_status.source_signed();
+        recv_tag                 = probe_status.tag();
+        recv_count_param.underlying() = asserting_cast<int>(probe_status.count(recv_type.get_single_element()));
+    }
+
+    // Ensure that we do not touch the recv buffer if MPI_PROC_NULL is passed,
+    // because this is what the standard guarantees.
+    // Resize the buffer if requested and ensure that it is large enough
+    if constexpr (std::remove_reference_t<decltype(source_param)>::rank_type != internal::RankType::null) {
+        auto compute_required_recv_buf_size = [&] {
+            return asserting_cast<size_t>(recv_count_param.get_single_element());
+        };
+        recv_buf.resize_if_requested(compute_required_recv_buf_size);
+        KASSERT(
+            // if the recv type is user provided, kamping cannot make any assumptions about the required size of the
+            // recv buffer
+            recv_type_is_in_param || recv_buf.size() >= compute_required_recv_buf_size(),
+            "Recv buffer is not large enough to hold all received elements.",
+            assert::light
+        );
+    }
+
+    [[maybe_unused]] int err = MPI_Sendrecv(
+        send_buf.data(),                                // send_buff
+        send_count.get_single_element(),                // send_count
+        send_type.get_single_element(),                 // send_data_type
+        destination.rank_singed(),                      // destination
+        send_tag,                                       // send_tag
+        recv_buf.data(),                                // recv_buff
+        recv_count_param.get_single_element(),          // recv_count
+        recv_type.get_single_element(),                 // recv_data_type
+        source,                                         // source
+        recv_tag,                                       // recv_tag
+        this->mpi_communicator(),                       // comm
+        internal::status_param_to_native_ptr(&status)   // status
+    );
+    this->mpi_error_hook(err);
+
+    return internal::make_mpi_result<std::tuple<Args...>>(
+        deserialization_repack<is_recv_serialization_used>(std::move(recv_buf)),
+        std::move(recv_count_param),
+        std::move(status),
+        std::move(recv_type)
+    );
+
+}

--- a/include/kamping/result.hpp
+++ b/include/kamping/result.hpp
@@ -889,6 +889,8 @@ using parameter_types_to_ignore_for_result_object = type_list<
     ParameterTypeEntry<ParameterType::request>,
     ParameterTypeEntry<ParameterType::root>,
     ParameterTypeEntry<ParameterType::tag>,
+    ParameterTypeEntry<ParameterType::send_tag>,
+    ParameterTypeEntry<ParameterType::recv_tag>,
     ParameterTypeEntry<ParameterType::send_mode>,
     ParameterTypeEntry<ParameterType::values_on_rank_0>>;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -139,6 +139,11 @@ kamping_register_mpi_test(
     CORES 1 2 4
 )
 kamping_register_mpi_test(
+    test_mpi_sendrecv
+    FILES p2p/mpi_sendrecv_test.cpp
+    CORES 2 4
+)
+kamping_register_mpi_test(
     test_mpi_try_recv
     FILES p2p/mpi_try_recv_test.cpp
     CORES 1 2 4

--- a/tests/p2p/mpi_sendrecv_test.cpp
+++ b/tests/p2p/mpi_sendrecv_test.cpp
@@ -1,0 +1,342 @@
+// This file is part of KaMPIng.
+//
+// Copyright 2025 The KaMPIng Authors
+//
+// KaMPIng is free software : you can redistribute it and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
+// version. KaMPIng is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+// implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+// for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along with KaMPIng.  If not, see
+// <https://www.gnu.org/licenses/>.
+
+#include "../test_assertions.hpp"
+
+#include <gtest/gtest.h>
+#include <mpi.h>
+
+#include "../helpers_for_testing.hpp"
+#include "kamping/communicator.hpp"
+#include "kamping/named_parameters.hpp"
+#include "kamping/p2p/sendrecv.hpp"
+#include "kamping/parameter_objects.hpp"
+
+using namespace kamping;
+using namespace ::testing;
+
+TEST(SendrecvTest, sendrecv_vector_cyclic) {
+    Communicator     comm;
+
+    std::vector<int> input(1, comm.rank_signed());
+    std::vector<int> message;
+    auto             sent_to = comm.rank_shifted_cyclic(1);
+    auto sent_from = comm.rank_shifted_cyclic(-1);
+
+    comm.sendrecv(
+        send_buf(input),
+        send_count(1),
+        destination(sent_to),
+        recv_buf<BufferResizePolicy::resize_to_fit>(message),
+        recv_count(1)
+    );
+
+    ASSERT_EQ(message, std::vector<int>{static_cast<int>(sent_from)});
+    ASSERT_EQ(message.size(), 1);
+}
+
+TEST(SendrecvTest, sendrecv_vector_cyclic_wo_recv_buf) {
+    Communicator     comm;
+
+    std::vector<int> input(1, comm.rank_signed());
+    auto             sent_to = comm.rank_shifted_cyclic(1);
+    auto sent_from = comm.rank_shifted_cyclic(-1);
+
+    auto message = comm.sendrecv<int>(
+        send_buf(input),
+        send_count(1),
+        destination(sent_to),
+        recv_count(1)
+    );
+
+    ASSERT_EQ(message, std::vector<int>{static_cast<int>(sent_from)});
+    ASSERT_EQ(message.size(), 1);
+}
+
+TEST(SendrecvTest, sendrecv_vector_cyclic_wo_recv_count) {
+    Communicator     comm;
+
+    std::vector<int> input(42, comm.rank_signed());
+    auto             sent_to = comm.rank_shifted_cyclic(1);
+    auto sent_from = comm.rank_shifted_cyclic(-1);
+
+    auto message = comm.sendrecv<int>(
+        send_buf(input),
+        send_count(42),
+        destination(sent_to)
+    );
+
+    ASSERT_EQ(message, std::vector<int>(42, static_cast<int>(sent_from)));
+    ASSERT_EQ(message.size(), 42);
+}
+
+TEST(SendrecvTest, send_and_recv_with_sendrecv) {
+    Communicator     comm;
+    ASSERT_GT(comm.size(), 1)
+        << "The invariants tested here only hold when the tests are executed using more than one MPI rank!";
+    auto         other_rank          = (comm.root() + 1) % comm.size();
+
+    if (comm.is_root()) {
+        std::vector<int> root_recv(3, 0);
+        MPI_Status       status;
+        MPI_Recv(
+            &root_recv[0],
+            3,
+            MPI_INT,
+            static_cast<int>(other_rank),
+            MPI_ANY_TAG,
+            comm.mpi_communicator(),
+            &status
+        );
+        ASSERT_EQ(root_recv, std::vector({11, 12, 13}));
+
+        std::vector<int> root_send{4, 5, 6, 7, 8, 9};
+        MPI_Send(
+            &root_send[0],
+            static_cast<int>(root_send.size()),
+            MPI_INT,
+            static_cast<int>(other_rank),
+            comm.rank_signed(),
+            comm.mpi_communicator()
+            );
+    }
+
+    if (comm.rank_shifted_cyclic(-1) == comm.root()) {
+        std::vector<int> msg{11, 12, 13};
+        auto message = comm.sendrecv<int>(
+            send_buf(msg),
+            destination(comm.root()),
+            recv_count(6)
+        );
+
+        ASSERT_EQ(message, std::vector({4, 5, 6, 7, 8, 9}));
+    }
+
+}
+
+TEST(SendrecvTest, sendrecv_cyclic_all_params) {
+    Communicator     comm;
+
+    std::vector<int> input(1, comm.rank_signed());
+    std::vector<int> message(1);
+    auto             sent_to = comm.rank_shifted_cyclic(1);
+    auto sent_from = comm.rank_shifted_cyclic(-1);
+
+    comm.sendrecv(
+        send_buf(input),
+        send_count(1),
+        destination(sent_to),
+        recv_buf<BufferResizePolicy::no_resize>(message),
+        recv_count(1),
+        send_type(MPI_INT),
+        send_tag(7),
+        recv_type(MPI_INT),
+        source(rank::any),
+        recv_tag(tags::any),
+        status(ignore<>)
+    );
+
+    ASSERT_EQ(message, std::vector<int>{static_cast<int>(sent_from)});
+    ASSERT_EQ(message.size(), 1);
+}
+
+TEST(SendrecvTest, sendrecv_cyclic_only_req_params) {
+    Communicator     comm;
+
+    std::vector<int> input(42, comm.rank_signed());
+    auto             sent_to = comm.rank_shifted_cyclic(1);
+    auto sent_from = comm.rank_shifted_cyclic(-1);
+
+    auto message = comm.sendrecv<int>(
+        send_buf(input),
+        destination(sent_to)
+    );
+
+    ASSERT_EQ(message, std::vector<int>(42, static_cast<int>(sent_from)));
+    ASSERT_EQ(message.size(), 42);
+}
+
+TEST(SendrecvTest, sendrecv_cyclic_with_status) {
+    Communicator     comm;
+
+    std::vector<int> input(42, comm.rank_signed());
+    auto             sent_to = comm.rank_shifted_cyclic(1);
+    auto sent_from = comm.rank_shifted_cyclic(-1);
+
+    auto result = comm.sendrecv<int>(
+        send_buf(input),
+        destination(sent_to),
+        status_out(),
+        recv_type_out()
+    );
+
+    auto message = result.extract_recv_buf();
+    ASSERT_EQ(message, std::vector<int>(42, static_cast<int>(sent_from)));
+    ASSERT_EQ(message.size(), 42);
+    auto status = result.extract_status();
+    auto source = status.source();
+    ASSERT_EQ(source, sent_from);
+    EXPECT_EQ(result.extract_recv_type(), MPI_INT);
+}
+
+TEST(SendrecvTest, sendrecv_different_send_and_recv_count) {
+    Communicator     comm;
+
+    std::vector<int> input(static_cast<size_t>(comm.rank_signed() + 10), comm.rank_signed());
+    auto             sent_to = comm.rank_shifted_cyclic(1);
+    auto sent_from = comm.rank_shifted_cyclic(-1);
+
+    auto message = comm.sendrecv<int>(
+        send_buf(input),
+        destination(sent_to)
+    );
+
+    ASSERT_EQ(message, std::vector<int>(sent_from + 10, static_cast<int>(sent_from)));
+    ASSERT_EQ(message.size(), sent_from + 10);
+}
+
+TEST(SendrecvTest, sendrecv_custom_container) {
+    Communicator     comm;
+    OwnContainer<int> values(4);
+    for (int & value : values) {
+        value = comm.rank_signed();
+    }
+    auto             sent_to = comm.rank_shifted_cyclic(1);
+    auto sent_from = comm.rank_shifted_cyclic(-1);
+
+    auto message = comm.sendrecv<int>(
+        send_buf(values),
+        destination(sent_to)
+    );
+
+    ASSERT_EQ(message.size(), 4);
+    for (int i : message) {
+        EXPECT_EQ(i, sent_from);
+    }
+}
+
+TEST(SendrecvTest, sendrecv_with_MPI_sendrecv) {
+    Communicator     comm;
+    ASSERT_GT(comm.size(), 1)
+        << "The invariants tested here only hold when the tests are executed using more than one MPI rank!";
+    auto         other_rank          = (comm.root() + 1) % comm.size();
+
+    if (comm.is_root()) {
+        std::vector<int> root_send(3, 0);
+        std::vector<int> root_recv(3);
+        MPI_Status       status;
+        MPI_Sendrecv(
+            &root_send[0],
+            3,
+            MPI_INT,
+            static_cast<int>(other_rank),
+            5,
+            &root_recv[0],
+            3,
+            MPI_INT,
+            asserting_cast<int>(other_rank),
+            MPI_ANY_TAG,
+            comm.mpi_communicator(),
+            &status
+        );
+        ASSERT_EQ(root_recv, std::vector<int>({11, 12, 13}));
+    }
+
+    if (comm.rank_shifted_cyclic(-1) == comm.root()) {
+        std::vector<int> msg{11, 12, 13};
+        auto message = comm.sendrecv<int>(
+            send_buf(msg),
+            destination(comm.root()),
+            recv_count(3)
+        );
+
+        ASSERT_EQ(message, std::vector<int>({0, 0, 0}));
+    }
+
+}
+
+TEST(SendrecvTest, sendrecv_different_types) {
+    Communicator     comm;
+    ASSERT_GT(comm.size(), 1)
+        << "The invariants tested here only hold when the tests are executed using more than one MPI rank!";
+    auto         other_rank          = (comm.root() + 1) % comm.size();
+
+    if (comm.is_root()) {
+        std::vector<char> root_send{'a', 'b', 'c'};
+        auto message = comm.sendrecv<int>(
+            send_buf(root_send),
+            destination(other_rank)
+        );
+        ASSERT_EQ(message, std::vector<int>({11, 12, 13, 14}));
+    }
+
+    if (comm.rank_shifted_cyclic(-1) == comm.root()) {
+        std::vector<int> msg{11, 12, 13, 14};
+        auto message = comm.sendrecv<char>(
+            send_buf(msg),
+            destination(comm.root())
+        );
+
+        ASSERT_EQ(message, std::vector<char>({'a', 'b', 'c'}));
+    }
+
+}
+
+TEST(SendrecvTest, sendrecv_different_types_with_explicit_buffer) {
+    Communicator     comm;
+    ASSERT_GT(comm.size(), 1)
+        << "The invariants tested here only hold when the tests are executed using more than one MPI rank!";
+    auto         other_rank          = (comm.root() + 1) % comm.size();
+
+    if (comm.is_root()) {
+        std::vector<char> root_send{'a', 'b', 'c'};
+        std::vector<int> root_recv;
+        comm.sendrecv(
+            send_buf(root_send),
+            destination(other_rank),
+            recv_buf<BufferResizePolicy::resize_to_fit>(root_recv)
+        );
+        ASSERT_EQ(root_recv, std::vector<int>({11, 12, 13, 14}));
+    }
+
+    if (comm.rank_shifted_cyclic(-1) == comm.root()) {
+        std::vector<int> msg_send{11, 12, 13, 14};
+        std::vector<char> msg_recv;
+        comm.sendrecv(
+            send_buf(msg_send),
+            destination(comm.root()),
+            recv_buf<BufferResizePolicy::resize_to_fit>(msg_recv)
+        );
+
+        ASSERT_EQ(msg_recv, std::vector<char>({'a', 'b', 'c'}));
+    }
+
+}
+
+#if KASSERT_ENABLED(KAMPING_ASSERTION_LEVEL_LIGHT)
+TEST(SendrecvTest, sendrecv_cyclic_with_explicit_size_no_resize_too_small) {
+    Communicator     comm;
+
+    std::vector<int> input(5, comm.rank_signed());
+    std::vector<int> msg_recv;
+    auto             sent_to = comm.rank_shifted_cyclic(1);
+
+    EXPECT_KASSERT_FAILS({comm.sendrecv(
+        send_buf(input),
+        destination(sent_to),
+        recv_buf<BufferResizePolicy::no_resize>(msg_recv),
+        recv_count(5)
+    );},"Recv buffer is not large enough to hold all received elements.");
+
+}
+#endif

--- a/tests/p2p/mpi_sendrecv_test.cpp
+++ b/tests/p2p/mpi_sendrecv_test.cpp
@@ -108,6 +108,8 @@ TEST(SendrecvTest, send_and_recv_with_sendrecv) {
 
         ASSERT_EQ(message, std::vector({4, 5, 6, 7, 8, 9}));
     }
+
+    MPI_Barrier(comm.mpi_communicator());
 }
 
 TEST(SendrecvTest, sendrecv_cyclic_all_params) {
@@ -230,6 +232,8 @@ TEST(SendrecvTest, sendrecv_with_MPI_sendrecv) {
 
         ASSERT_EQ(message, std::vector<int>({0, 0, 0}));
     }
+
+    MPI_Barrier(comm.mpi_communicator());
 }
 
 TEST(SendrecvTest, sendrecv_different_types) {
@@ -250,6 +254,8 @@ TEST(SendrecvTest, sendrecv_different_types) {
 
         ASSERT_EQ(message, std::vector<char>({'a', 'b', 'c'}));
     }
+
+    MPI_Barrier(comm.mpi_communicator());
 }
 
 TEST(SendrecvTest, sendrecv_different_types_with_explicit_buffer) {
@@ -280,6 +286,8 @@ TEST(SendrecvTest, sendrecv_different_types_with_explicit_buffer) {
 
         ASSERT_EQ(msg_recv, std::vector<char>({'a', 'b', 'c'}));
     }
+
+    MPI_Barrier(comm.mpi_communicator());
 }
 
 #if KASSERT_ENABLED(KAMPING_ASSERTION_LEVEL_LIGHT)

--- a/tests/p2p/mpi_sendrecv_test.cpp
+++ b/tests/p2p/mpi_sendrecv_test.cpp
@@ -26,12 +26,12 @@ using namespace kamping;
 using namespace ::testing;
 
 TEST(SendrecvTest, sendrecv_vector_cyclic) {
-    Communicator     comm;
+    Communicator comm;
 
     std::vector<int> input(1, comm.rank_signed());
     std::vector<int> message;
-    auto             sent_to = comm.rank_shifted_cyclic(1);
-    auto sent_from = comm.rank_shifted_cyclic(-1);
+    auto             sent_to   = comm.rank_shifted_cyclic(1);
+    auto             sent_from = comm.rank_shifted_cyclic(-1);
 
     comm.sendrecv(
         send_buf(input),
@@ -46,45 +46,36 @@ TEST(SendrecvTest, sendrecv_vector_cyclic) {
 }
 
 TEST(SendrecvTest, sendrecv_vector_cyclic_wo_recv_buf) {
-    Communicator     comm;
+    Communicator comm;
 
     std::vector<int> input(1, comm.rank_signed());
-    auto             sent_to = comm.rank_shifted_cyclic(1);
-    auto sent_from = comm.rank_shifted_cyclic(-1);
+    auto             sent_to   = comm.rank_shifted_cyclic(1);
+    auto             sent_from = comm.rank_shifted_cyclic(-1);
 
-    auto message = comm.sendrecv<int>(
-        send_buf(input),
-        send_count(1),
-        destination(sent_to),
-        recv_count(1)
-    );
+    auto message = comm.sendrecv<int>(send_buf(input), send_count(1), destination(sent_to), recv_count(1));
 
     ASSERT_EQ(message, std::vector<int>{static_cast<int>(sent_from)});
     ASSERT_EQ(message.size(), 1);
 }
 
 TEST(SendrecvTest, sendrecv_vector_cyclic_wo_recv_count) {
-    Communicator     comm;
+    Communicator comm;
 
     std::vector<int> input(42, comm.rank_signed());
-    auto             sent_to = comm.rank_shifted_cyclic(1);
-    auto sent_from = comm.rank_shifted_cyclic(-1);
+    auto             sent_to   = comm.rank_shifted_cyclic(1);
+    auto             sent_from = comm.rank_shifted_cyclic(-1);
 
-    auto message = comm.sendrecv<int>(
-        send_buf(input),
-        send_count(42),
-        destination(sent_to)
-    );
+    auto message = comm.sendrecv<int>(send_buf(input), send_count(42), destination(sent_to));
 
     ASSERT_EQ(message, std::vector<int>(42, static_cast<int>(sent_from)));
     ASSERT_EQ(message.size(), 42);
 }
 
 TEST(SendrecvTest, send_and_recv_with_sendrecv) {
-    Communicator     comm;
+    Communicator comm;
     ASSERT_GT(comm.size(), 1)
         << "The invariants tested here only hold when the tests are executed using more than one MPI rank!";
-    auto         other_rank          = (comm.root() + 1) % comm.size();
+    auto other_rank = (comm.root() + 1) % comm.size();
 
     if (comm.is_root()) {
         std::vector<int> root_recv(3, 0);
@@ -108,29 +99,24 @@ TEST(SendrecvTest, send_and_recv_with_sendrecv) {
             static_cast<int>(other_rank),
             comm.rank_signed(),
             comm.mpi_communicator()
-            );
+        );
     }
 
     if (comm.rank_shifted_cyclic(-1) == comm.root()) {
         std::vector<int> msg{11, 12, 13};
-        auto message = comm.sendrecv<int>(
-            send_buf(msg),
-            destination(comm.root()),
-            recv_count(6)
-        );
+        auto             message = comm.sendrecv<int>(send_buf(msg), destination(comm.root()), recv_count(6));
 
         ASSERT_EQ(message, std::vector({4, 5, 6, 7, 8, 9}));
     }
-
 }
 
 TEST(SendrecvTest, sendrecv_cyclic_all_params) {
-    Communicator     comm;
+    Communicator comm;
 
     std::vector<int> input(1, comm.rank_signed());
     std::vector<int> message(1);
-    auto             sent_to = comm.rank_shifted_cyclic(1);
-    auto sent_from = comm.rank_shifted_cyclic(-1);
+    auto             sent_to   = comm.rank_shifted_cyclic(1);
+    auto             sent_from = comm.rank_shifted_cyclic(-1);
 
     comm.sendrecv(
         send_buf(input),
@@ -151,34 +137,26 @@ TEST(SendrecvTest, sendrecv_cyclic_all_params) {
 }
 
 TEST(SendrecvTest, sendrecv_cyclic_only_req_params) {
-    Communicator     comm;
+    Communicator comm;
 
     std::vector<int> input(42, comm.rank_signed());
-    auto             sent_to = comm.rank_shifted_cyclic(1);
-    auto sent_from = comm.rank_shifted_cyclic(-1);
+    auto             sent_to   = comm.rank_shifted_cyclic(1);
+    auto             sent_from = comm.rank_shifted_cyclic(-1);
 
-    auto message = comm.sendrecv<int>(
-        send_buf(input),
-        destination(sent_to)
-    );
+    auto message = comm.sendrecv<int>(send_buf(input), destination(sent_to));
 
     ASSERT_EQ(message, std::vector<int>(42, static_cast<int>(sent_from)));
     ASSERT_EQ(message.size(), 42);
 }
 
 TEST(SendrecvTest, sendrecv_cyclic_with_status) {
-    Communicator     comm;
+    Communicator comm;
 
     std::vector<int> input(42, comm.rank_signed());
-    auto             sent_to = comm.rank_shifted_cyclic(1);
-    auto sent_from = comm.rank_shifted_cyclic(-1);
+    auto             sent_to   = comm.rank_shifted_cyclic(1);
+    auto             sent_from = comm.rank_shifted_cyclic(-1);
 
-    auto result = comm.sendrecv<int>(
-        send_buf(input),
-        destination(sent_to),
-        status_out(),
-        recv_type_out()
-    );
+    auto result = comm.sendrecv<int>(send_buf(input), destination(sent_to), status_out(), recv_type_out());
 
     auto message = result.extract_recv_buf();
     ASSERT_EQ(message, std::vector<int>(42, static_cast<int>(sent_from)));
@@ -190,46 +168,40 @@ TEST(SendrecvTest, sendrecv_cyclic_with_status) {
 }
 
 TEST(SendrecvTest, sendrecv_different_send_and_recv_count) {
-    Communicator     comm;
+    Communicator comm;
 
     std::vector<int> input(static_cast<size_t>(comm.rank_signed() + 10), comm.rank_signed());
-    auto             sent_to = comm.rank_shifted_cyclic(1);
-    auto sent_from = comm.rank_shifted_cyclic(-1);
+    auto             sent_to   = comm.rank_shifted_cyclic(1);
+    auto             sent_from = comm.rank_shifted_cyclic(-1);
 
-    auto message = comm.sendrecv<int>(
-        send_buf(input),
-        destination(sent_to)
-    );
+    auto message = comm.sendrecv<int>(send_buf(input), destination(sent_to));
 
     ASSERT_EQ(message, std::vector<int>(sent_from + 10, static_cast<int>(sent_from)));
     ASSERT_EQ(message.size(), sent_from + 10);
 }
 
 TEST(SendrecvTest, sendrecv_custom_container) {
-    Communicator     comm;
+    Communicator      comm;
     OwnContainer<int> values(4);
-    for (int & value : values) {
+    for (int& value: values) {
         value = comm.rank_signed();
     }
-    auto             sent_to = comm.rank_shifted_cyclic(1);
+    auto sent_to   = comm.rank_shifted_cyclic(1);
     auto sent_from = comm.rank_shifted_cyclic(-1);
 
-    auto message = comm.sendrecv<int>(
-        send_buf(values),
-        destination(sent_to)
-    );
+    auto message = comm.sendrecv<int>(send_buf(values), destination(sent_to));
 
     ASSERT_EQ(message.size(), 4);
-    for (int i : message) {
+    for (int i: message) {
         EXPECT_EQ(i, sent_from);
     }
 }
 
 TEST(SendrecvTest, sendrecv_with_MPI_sendrecv) {
-    Communicator     comm;
+    Communicator comm;
     ASSERT_GT(comm.size(), 1)
         << "The invariants tested here only hold when the tests are executed using more than one MPI rank!";
-    auto         other_rank          = (comm.root() + 1) % comm.size();
+    auto other_rank = (comm.root() + 1) % comm.size();
 
     if (comm.is_root()) {
         std::vector<int> root_send(3, 0);
@@ -254,53 +226,41 @@ TEST(SendrecvTest, sendrecv_with_MPI_sendrecv) {
 
     if (comm.rank_shifted_cyclic(-1) == comm.root()) {
         std::vector<int> msg{11, 12, 13};
-        auto message = comm.sendrecv<int>(
-            send_buf(msg),
-            destination(comm.root()),
-            recv_count(3)
-        );
+        auto             message = comm.sendrecv<int>(send_buf(msg), destination(comm.root()), recv_count(3));
 
         ASSERT_EQ(message, std::vector<int>({0, 0, 0}));
     }
-
 }
 
 TEST(SendrecvTest, sendrecv_different_types) {
-    Communicator     comm;
+    Communicator comm;
     ASSERT_GT(comm.size(), 1)
         << "The invariants tested here only hold when the tests are executed using more than one MPI rank!";
-    auto         other_rank          = (comm.root() + 1) % comm.size();
+    auto other_rank = (comm.root() + 1) % comm.size();
 
     if (comm.is_root()) {
         std::vector<char> root_send{'a', 'b', 'c'};
-        auto message = comm.sendrecv<int>(
-            send_buf(root_send),
-            destination(other_rank)
-        );
+        auto              message = comm.sendrecv<int>(send_buf(root_send), destination(other_rank));
         ASSERT_EQ(message, std::vector<int>({11, 12, 13, 14}));
     }
 
     if (comm.rank_shifted_cyclic(-1) == comm.root()) {
         std::vector<int> msg{11, 12, 13, 14};
-        auto message = comm.sendrecv<char>(
-            send_buf(msg),
-            destination(comm.root())
-        );
+        auto             message = comm.sendrecv<char>(send_buf(msg), destination(comm.root()));
 
         ASSERT_EQ(message, std::vector<char>({'a', 'b', 'c'}));
     }
-
 }
 
 TEST(SendrecvTest, sendrecv_different_types_with_explicit_buffer) {
-    Communicator     comm;
+    Communicator comm;
     ASSERT_GT(comm.size(), 1)
         << "The invariants tested here only hold when the tests are executed using more than one MPI rank!";
-    auto         other_rank          = (comm.root() + 1) % comm.size();
+    auto other_rank = (comm.root() + 1) % comm.size();
 
     if (comm.is_root()) {
         std::vector<char> root_send{'a', 'b', 'c'};
-        std::vector<int> root_recv;
+        std::vector<int>  root_recv;
         comm.sendrecv(
             send_buf(root_send),
             destination(other_rank),
@@ -310,7 +270,7 @@ TEST(SendrecvTest, sendrecv_different_types_with_explicit_buffer) {
     }
 
     if (comm.rank_shifted_cyclic(-1) == comm.root()) {
-        std::vector<int> msg_send{11, 12, 13, 14};
+        std::vector<int>  msg_send{11, 12, 13, 14};
         std::vector<char> msg_recv;
         comm.sendrecv(
             send_buf(msg_send),
@@ -320,23 +280,26 @@ TEST(SendrecvTest, sendrecv_different_types_with_explicit_buffer) {
 
         ASSERT_EQ(msg_recv, std::vector<char>({'a', 'b', 'c'}));
     }
-
 }
 
 #if KASSERT_ENABLED(KAMPING_ASSERTION_LEVEL_LIGHT)
 TEST(SendrecvTest, sendrecv_cyclic_with_explicit_size_no_resize_too_small) {
-    Communicator     comm;
+    Communicator comm;
 
     std::vector<int> input(5, comm.rank_signed());
     std::vector<int> msg_recv;
     auto             sent_to = comm.rank_shifted_cyclic(1);
 
-    EXPECT_KASSERT_FAILS({comm.sendrecv(
-        send_buf(input),
-        destination(sent_to),
-        recv_buf<BufferResizePolicy::no_resize>(msg_recv),
-        recv_count(5)
-    );},"Recv buffer is not large enough to hold all received elements.");
-
+    EXPECT_KASSERT_FAILS(
+        {
+            comm.sendrecv(
+                send_buf(input),
+                destination(sent_to),
+                recv_buf<BufferResizePolicy::no_resize>(msg_recv),
+                recv_count(5)
+            );
+        },
+        "Recv buffer is not large enough to hold all received elements."
+    );
 }
 #endif

--- a/tests/p2p/mpi_sendrecv_test.cpp
+++ b/tests/p2p/mpi_sendrecv_test.cpp
@@ -43,6 +43,8 @@ TEST(SendrecvTest, sendrecv_vector_cyclic) {
 
     ASSERT_EQ(message, std::vector<int>{static_cast<int>(sent_from)});
     ASSERT_EQ(message.size(), 1);
+
+    MPI_Barrier(comm.mpi_communicator());
 }
 
 TEST(SendrecvTest, sendrecv_vector_cyclic_wo_recv_buf) {
@@ -56,6 +58,8 @@ TEST(SendrecvTest, sendrecv_vector_cyclic_wo_recv_buf) {
 
     ASSERT_EQ(message, std::vector<int>{static_cast<int>(sent_from)});
     ASSERT_EQ(message.size(), 1);
+
+    MPI_Barrier(comm.mpi_communicator());
 }
 
 TEST(SendrecvTest, sendrecv_vector_cyclic_wo_recv_count) {
@@ -69,6 +73,8 @@ TEST(SendrecvTest, sendrecv_vector_cyclic_wo_recv_count) {
 
     ASSERT_EQ(message, std::vector<int>(42, static_cast<int>(sent_from)));
     ASSERT_EQ(message.size(), 42);
+
+    MPI_Barrier(comm.mpi_communicator());
 }
 
 TEST(SendrecvTest, send_and_recv_with_sendrecv) {
@@ -136,6 +142,8 @@ TEST(SendrecvTest, sendrecv_cyclic_all_params) {
 
     ASSERT_EQ(message, std::vector<int>{static_cast<int>(sent_from)});
     ASSERT_EQ(message.size(), 1);
+
+    MPI_Barrier(comm.mpi_communicator());
 }
 
 TEST(SendrecvTest, sendrecv_cyclic_only_req_params) {
@@ -149,6 +157,8 @@ TEST(SendrecvTest, sendrecv_cyclic_only_req_params) {
 
     ASSERT_EQ(message, std::vector<int>(42, static_cast<int>(sent_from)));
     ASSERT_EQ(message.size(), 42);
+
+    MPI_Barrier(comm.mpi_communicator());
 }
 
 TEST(SendrecvTest, sendrecv_cyclic_with_status) {
@@ -167,6 +177,8 @@ TEST(SendrecvTest, sendrecv_cyclic_with_status) {
     auto source = status.source();
     ASSERT_EQ(source, sent_from);
     EXPECT_EQ(result.extract_recv_type(), MPI_INT);
+
+    MPI_Barrier(comm.mpi_communicator());
 }
 
 TEST(SendrecvTest, sendrecv_different_send_and_recv_count) {
@@ -180,6 +192,8 @@ TEST(SendrecvTest, sendrecv_different_send_and_recv_count) {
 
     ASSERT_EQ(message, std::vector<int>(sent_from + 10, static_cast<int>(sent_from)));
     ASSERT_EQ(message.size(), sent_from + 10);
+
+    MPI_Barrier(comm.mpi_communicator());
 }
 
 TEST(SendrecvTest, sendrecv_custom_container) {
@@ -197,6 +211,8 @@ TEST(SendrecvTest, sendrecv_custom_container) {
     for (int i: message) {
         EXPECT_EQ(i, sent_from);
     }
+
+    MPI_Barrier(comm.mpi_communicator());
 }
 
 TEST(SendrecvTest, sendrecv_with_MPI_sendrecv) {
@@ -309,5 +325,7 @@ TEST(SendrecvTest, sendrecv_cyclic_with_explicit_size_no_resize_too_small) {
         },
         "Recv buffer is not large enough to hold all received elements."
     );
+
+    MPI_Barrier(comm.mpi_communicator());
 }
 #endif


### PR DESCRIPTION
Add sendrecv implementation (Issue #763). 
* Add sendrecv in communicator.hpp
* Implement sendrecv.hpp
* Make revc_count a required parameter, as probing it would result in a deadlock.
* Add example for sendrecv