### PR TITLE
KaMPIng requires GNU extensions

### DIFF
--- a/include/kamping/named_parameter_check.hpp
+++ b/include/kamping/named_parameter_check.hpp
@@ -49,13 +49,13 @@
 /// KAMPING_CHECK_PARAMETERS.
 /// Note that this macro only takes the *name* of parameter types, i.e., instead of using
 /// `kamping::internal::ParameterType::send_buf`, only pass `send_buf` to this macro.
-#define KAMPING_REQUIRED_PARAMETERS(...) , ##__VA_ARGS__
+#define KAMPING_REQUIRED_PARAMETERS(...) __VA_OPT__(, __VA_ARGS__)
 
 /// @brief Wrapper to pass (possibly empty) list of parameter type names as optional parameters to \c
 /// KAMPING_CHECK_PARAMETERS.
 /// Note that this macro only takes the *name* of parameter types, i.e., instead of using
 /// `kamping::internal::ParameterType::send_buf`, only pass `send_buf` to this macro.
-#define KAMPING_OPTIONAL_PARAMETERS(...) , ##__VA_ARGS__
+#define KAMPING_OPTIONAL_PARAMETERS(...) __VA_OPT__(, __VA_ARGS__)
 
 /// @brief Assertion macro that checks if passed parameters are correct, i.e., all parameter types are unique, all
 /// required parameters are provided, and no unused parameter is passed. Also checks that all parameter types are


### PR DESCRIPTION
Currently, KaMPIng (and kassert) rely on GNU extensions in the macros for parameter checks:
`##__VA_ARGS__` is not standard compliant, but `__VA_OPT__` is (but it's a C++20 feature).

Still, compiler support is good [^1], supported by `gcc` 8 and `clang` 12, so we should use it whenever possible. 

[^1] https://en.cppreference.com/w/c/compiler_support