### PR TITLE
Fix compilation of sort plugin on macOS.

### DIFF
--- a/include/kamping/plugin/sort.hpp
+++ b/include/kamping/plugin/sort.hpp
@@ -57,7 +57,7 @@ public:
             data.end(),
             local_samples.begin(),
             oversampling_ratio,
-            std::mt19937{self.rank() + self.size()}
+            std::mt19937{static_cast<std::mt19937::result_type>(self.rank() + self.size())}
         );
 
         auto global_samples = self.allgatherv(send_buf(local_samples));


### PR DESCRIPTION
`std::mt19937::result_type` (the type used for seeding the RNG) is `std::uint_fast32_t`, and we pass a `std::size_t`. That works fine when building on UNIX, but on macOS we are assigning `unsigned long` to `unsigned int`.

We therefore need to cast explicitely.