### PR TITLE
fix: propagate kamping_lookup through type_dispatcher for array element types

### DIFF
--- a/include/kamping/mpi_datatype.hpp
+++ b/include/kamping/mpi_datatype.hpp
@@ -38,17 +38,24 @@ namespace kamping {
 // Re-export no_matching_type into kamping:: for backward compatibility
 using internal::no_matching_type;
 
+// Forward declaration: fully defined below, after mpi_type_traits.
+struct kamping_lookup;
+
 /// @brief Maps a C++ type \p T to a type trait for constructing an MPI_Datatype.
 ///
 /// Extends \ref kamping::types::type_dispatcher() with:
 /// - All trivially copyable types not otherwise handled → `types::byte_serialized`.
 ///
+/// \ref kamping_lookup is forwarded into \ref kamping::types::type_dispatcher() so that array and
+/// enum branches resolve element types via the kamping layer (which includes the byte-serialization
+/// fallback for trivially-copyable types).
+///
 /// @returns The corresponding type trait for the type \p T.
 template <typename T>
 auto type_dispatcher() {
     using T_no_const = std::remove_const_t<T>;
-    if constexpr (types::has_auto_dispatched_type_v<T>) {
-        return types::type_dispatcher<T>();
+    if constexpr (types::has_auto_dispatched_type_v<T, kamping_lookup>) {
+        return types::type_dispatcher<T, kamping_lookup>();
     } else if constexpr (std::is_trivially_copyable_v<T_no_const>) {
         return types::byte_serialized<T_no_const>{};
     } else {

--- a/kamping-types/include/kamping/types/mpi_type_traits.hpp
+++ b/kamping-types/include/kamping/types/mpi_type_traits.hpp
@@ -31,14 +31,20 @@ namespace kamping::types {
 /// | C++ type | Result |
 /// |----------|--------|
 /// | MPI builtin (`int`, `double`, …, `kabool`) | `builtin_type<T>` |
-/// | Enum | dispatches to `type_dispatcher<underlying_type>()` |
-/// | `T[N]`, `std::array<T, N>` | `contiguous_type<T, N>` |
+/// | Enum | dispatches to `type_dispatcher<underlying_type, Lookup>()` |
+/// | `T[N]`, `std::array<T, N>` | `contiguous_type<T, N, Lookup>` |
 /// | Everything else | `internal::no_matching_type` |
 ///
 /// Specialize \ref kamping::types::mpi_type_traits to handle additional types.
 ///
+/// @tparam T The C++ type to map.
+/// @tparam Lookup The lookup policy used to resolve element types inside array and enum branches.
+///   Defaults to \ref type_dispatcher_lookup (module-level resolution via
+///   \ref kamping::types::mpi_type_traits). Upper-level frameworks (e.g., full KaMPIng) pass
+///   \ref kamping::kamping_lookup so that array element types benefit from the byte-serialization
+///   fallback.
 /// @returns The corresponding type trait for the type \p T.
-template <typename T>
+template <typename T, typename Lookup = type_dispatcher_lookup>
 auto type_dispatcher() {
     using T_no_const = std::remove_const_t<T>;
 
@@ -53,22 +59,26 @@ auto type_dispatcher() {
     if constexpr (is_builtin_type_v<T_no_const>) {
         return builtin_type<T_no_const>{};
     } else if constexpr (std::is_enum_v<T_no_const>) {
-        return type_dispatcher<std::underlying_type_t<T_no_const>>();
+        return type_dispatcher<std::underlying_type_t<T_no_const>, Lookup>();
     } else if constexpr (std::is_array_v<T_no_const>) {
-        return contiguous_type<std::remove_extent_t<T_no_const>, std::extent_v<T_no_const>>{};
+        return contiguous_type<std::remove_extent_t<T_no_const>, std::extent_v<T_no_const>, Lookup>{};
     } else if constexpr (kamping::internal::is_std_array<T_no_const>::value) {
         return contiguous_type<
             typename kamping::internal::is_std_array<T_no_const>::value_type,
-            kamping::internal::is_std_array<T_no_const>::size>{};
+            kamping::internal::is_std_array<T_no_const>::size,
+            Lookup>{};
     } else {
         return kamping::internal::no_matching_type{};
     }
 }
 
 /// @brief Whether the type is handled by the auto-dispatcher \ref kamping::types::type_dispatcher().
-template <typename T>
+/// @tparam T The C++ type to check.
+/// @tparam Lookup The lookup policy forwarded to \ref kamping::types::type_dispatcher(). Defaults to
+///   \ref type_dispatcher_lookup so all existing call sites are unaffected.
+template <typename T, typename Lookup = type_dispatcher_lookup>
 static constexpr bool has_auto_dispatched_type_v =
-    !std::is_same_v<decltype(type_dispatcher<T>()), kamping::internal::no_matching_type>;
+    !std::is_same_v<decltype(type_dispatcher<T, Lookup>()), kamping::internal::no_matching_type>;
 
 /// @brief The type trait that maps a C++ type \p T to an MPI_Datatype for the kamping-types module.
 ///

--- a/tests/mpi_datatype_test.cpp
+++ b/tests/mpi_datatype_test.cpp
@@ -800,17 +800,11 @@ TEST(MpiDataTypeTest, mpi_datatype_array_of_trivially_copyable) {
     // between independently-allocated MPI types of the same structure).
     auto elem_matcher = ContiguousType(MPI_BYTE, sizeof(TrivialStruct));
     {
-        EXPECT_THAT(
-            (mpi_type_traits<std::array<TrivialStruct, 3>>::data_type()),
-            ContiguousType(elem_matcher, 3)
-        );
+        EXPECT_THAT((mpi_type_traits<std::array<TrivialStruct, 3>>::data_type()), ContiguousType(elem_matcher, 3));
         EXPECT_EQ((mpi_type_traits<std::array<TrivialStruct, 3>>::category), TypeCategory::contiguous);
     }
     {
-        EXPECT_THAT(
-            (mpi_type_traits<TrivialStruct[3]>::data_type()),
-            ContiguousType(elem_matcher, 3)
-        );
+        EXPECT_THAT((mpi_type_traits<TrivialStruct[3]>::data_type()), ContiguousType(elem_matcher, 3));
         EXPECT_EQ((mpi_type_traits<TrivialStruct[3]>::category), TypeCategory::contiguous);
     }
 }

--- a/tests/mpi_datatype_test.cpp
+++ b/tests/mpi_datatype_test.cpp
@@ -87,7 +87,7 @@ MATCHER_P2(ContiguousType, type, n, "") {
         *result_listener << "wrong count";
         return false;
     }
-    return underlying_type == type;
+    return ExplainMatchResult(type, underlying_type, result_listener);
 }
 
 class StructTypeMatcher {
@@ -783,6 +783,35 @@ TEST(MpiDataTypeTest, mpi_datatype_c_array) {
         std::array<double, 3> cpp_array;
         EXPECT_THAT(mpi_type_traits<decltype(cpp_array)>::data_type(), ContiguousType(MPI_DOUBLE, 3));
         EXPECT_EQ(mpi_type_traits<decltype(cpp_array)>::category, TypeCategory::contiguous);
+    }
+}
+
+TEST(MpiDataTypeTest, mpi_datatype_array_of_trivially_copyable) {
+    // std::array and C-arrays of trivially-copyable (but non-builtin) types should be handled by
+    // resolving each element via kamping_lookup, which byte-serializes it. The result is a nested
+    // contiguous type: contiguous(N, contiguous(sizeof(T), MPI_BYTE)).
+    struct TrivialStruct {
+        int   a;
+        float b;
+    };
+    static_assert(std::is_trivially_copyable_v<TrivialStruct>);
+    // The expected structure is contiguous(N, contiguous(sizeof(T), MPI_BYTE)).
+    // Use nested ContiguousType matchers for structural comparison (pointer identity would differ
+    // between independently-allocated MPI types of the same structure).
+    auto elem_matcher = ContiguousType(MPI_BYTE, sizeof(TrivialStruct));
+    {
+        EXPECT_THAT(
+            (mpi_type_traits<std::array<TrivialStruct, 3>>::data_type()),
+            ContiguousType(elem_matcher, 3)
+        );
+        EXPECT_EQ((mpi_type_traits<std::array<TrivialStruct, 3>>::category), TypeCategory::contiguous);
+    }
+    {
+        EXPECT_THAT(
+            (mpi_type_traits<TrivialStruct[3]>::data_type()),
+            ContiguousType(elem_matcher, 3)
+        );
+        EXPECT_EQ((mpi_type_traits<TrivialStruct[3]>::category), TypeCategory::contiguous);
     }
 }
 


### PR DESCRIPTION
## Summary

- `kamping::types::type_dispatcher` and `has_auto_dispatched_type_v` gain an optional `Lookup` template parameter (default: `type_dispatcher_lookup`) that is forwarded into the C-array, `std::array`, and enum branches — all existing call sites are unaffected.
- `kamping::type_dispatcher` now passes `kamping_lookup` when calling into `kamping::types::type_dispatcher`, so element types of `T[N]` and `std::array<T, N>` are resolved via the kamping layer (which includes the byte-serialization fallback for trivially-copyable types).
- `ContiguousType` GTest matcher updated to use `ExplainMatchResult`, enabling nested matchers as the element-type argument.

## Motivation

Before this fix, `mpi_datatype<std::array<TrivialStruct, N>>()` (where `TrivialStruct` is trivially copyable but not an MPI builtin) failed to compile: `contiguous_type` resolved the element type via `type_dispatcher_lookup` → `kamping::types::mpi_type_traits<TrivialStruct>`, which has no specialization. With this fix the element type is resolved through `kamping_lookup` → `kamping::mpi_type_traits<TrivialStruct>`, which byte-serializes it.

## Test plan

- [x] `ctest --preset debug -R test_mpi_datatype` — all 5 test targets pass, including the new `mpi_datatype_array_of_trivially_copyable` case
- [x] Existing tests (`mpi_datatype_c_array`, `mpi_datatype_struct`, `mpi_datatype_enum`, …) continue to pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)