### PR TITLE
kamping-types: add std lib type specializations (std/ hierarchy)

### DIFF
--- a/kamping-types/README.md
+++ b/kamping-types/README.md
@@ -199,10 +199,3 @@ kamping::ops::commutative      // ops::internal::commutative_tag
 kamping::ops::non_commutative  // ops::internal::non_commutative_tag
 ```
 
-## When Using Full KaMPIng
-
-When linking against `kamping::kamping` instead of `kamping::types`, you additionally get:
-
-- `type_dispatcher<T>()` — also maps trivially-copyable types to `byte_serialized<T>` automatically (no opt-in needed)
-- `mpi_datatype<T>()` — returns a committed, environment-managed `MPI_Datatype`
-- `include/kamping/types/utility.hpp` and `include/kamping/types/tuple.hpp` — additionally specialize `kamping::mpi_type_traits` (the full KaMPIng trait) for `std::pair` and `std::tuple`; use these instead of the `kamping/types/std/` headers when working with the full KaMPIng communicator

--- a/kamping-types/README.md
+++ b/kamping-types/README.md
@@ -44,6 +44,8 @@ MPI_Send(data, 1, arr_type.data_type(), dest, tag, MPI_COMM_WORLD);
 
 ## Headers
 
+### Core
+
 | Header | Contents |
 |--------|----------|
 | `kamping/types/builtin_types.hpp` | `TypeCategory`, `builtin_type<T>`, `is_builtin_type_v<T>` |
@@ -53,6 +55,18 @@ MPI_Send(data, 1, arr_type.data_type(), dest, tag, MPI_COMM_WORLD);
 | `kamping/types/scoped_datatype.hpp` | `ScopedDatatype` — RAII commit/free wrapper |
 | `kamping/types/kabool.hpp` | `kabool` — bool wrapper safe for MPI containers |
 | `kamping/types/reduce_ops.hpp` | `kamping::ops::` functors, `mpi_operation_traits<Op,T>`, `ScopedOp`, `with_operation_functor` |
+
+### Opt-in standard library specializations (`kamping/types/std/`)
+
+These headers register standard library types with `mpi_type_traits`. Include only what you need; the safe and unsafe variants for the same type are mutually exclusive.
+
+| Header | Type | How |
+|--------|------|-----|
+| `kamping/types/std/utility.hpp` | `std::pair<F,S>` | `struct_type` — models field layout; field types must have a static MPI type |
+| `kamping/types/std/tuple.hpp` | `std::tuple<Ts...>` | `struct_type` — models field layout; all element types must have a static MPI type |
+| `kamping/types/std/unsafe/utility.hpp` | `std::pair<F,S>` | `byte_serialized` — flat byte copy; ignores padding |
+| `kamping/types/std/unsafe/tuple.hpp` | `std::tuple<Ts...>` | `byte_serialized` — flat byte copy; ignores padding |
+| `kamping/types/std/unsafe/trivially_copyable.hpp` | any `std::is_trivially_copyable<T>` not already registered | `byte_serialized` — catch-all; excludes `std::pair`/`std::tuple` so it composes with the above |
 
 ## Type Dispatch Rules
 
@@ -69,17 +83,31 @@ Use `has_static_type_v<T>` to check at compile time whether a type is handled.
 
 ## Extending for Custom Types
 
-Specialize `mpi_type_traits<T>` to support your own types:
+For `std::pair` and `std::tuple`, include the ready-made headers from `kamping/types/std/`:
 
 ```cpp
-struct Point { float x, y, z; };
+#include "kamping/types/std/utility.hpp"  // std::pair via struct_type (safe)
+#include "kamping/types/std/tuple.hpp"    // std::tuple via struct_type (safe)
+
+static_assert(kamping::types::has_static_type_v<std::pair<int, double>>); // true
+```
+
+For your own types, specialize `mpi_type_traits<T>` directly:
+
+```cpp
+struct Particle { float position[3]; double mass; };
+struct Point    { float x, y, z; };  // tightly packed — byte serialization is safe
 
 namespace kamping::types {
-// Option 1: use struct_type (requires std::pair/std::tuple, or Boost.PFR reflection)
+// Option 1: struct_type — correct field-aware layout (requires Boost.PFR or std::pair/tuple)
 template <>
-struct mpi_type_traits<std::pair<int, double>> : struct_type<std::pair<int, double>> {};
+struct mpi_type_traits<Particle> : struct_type<Particle> {};
 
-// Option 2: build the type manually
+// Option 2: byte_serialized — flat byte copy; only correct when there is no padding
+template <>
+struct mpi_type_traits<Point> : byte_serialized<Point> {};
+
+// Option 3: build the MPI_Datatype manually for full control
 template <>
 struct mpi_type_traits<Point> {
     static constexpr bool has_to_be_committed = true;
@@ -90,6 +118,15 @@ struct mpi_type_traits<Point> {
     }
 };
 } // namespace kamping::types
+```
+
+To register all trivially copyable types at once, include the catch-all:
+
+```cpp
+#include "kamping/types/std/unsafe/trivially_copyable.hpp"
+
+struct Point { float x, y, z; };
+static_assert(kamping::types::has_static_type_v<Point>); // true — registered automatically
 ```
 
 ## Reduction Operations
@@ -166,7 +203,6 @@ kamping::ops::non_commutative  // ops::internal::non_commutative_tag
 
 When linking against `kamping::kamping` instead of `kamping::types`, you additionally get:
 
-- `type_dispatcher<T>()` — also maps trivially-copyable types to `byte_serialized<T>`
+- `type_dispatcher<T>()` — also maps trivially-copyable types to `byte_serialized<T>` automatically (no opt-in needed)
 - `mpi_datatype<T>()` — returns a committed, environment-managed `MPI_Datatype`
-- `include/kamping/types/utility.hpp` — `mpi_type_traits` for `std::pair`
-- `include/kamping/types/tuple.hpp` — `mpi_type_traits` for `std::tuple`
+- `include/kamping/types/utility.hpp` and `include/kamping/types/tuple.hpp` — additionally specialize `kamping::mpi_type_traits` (the full KaMPIng trait) for `std::pair` and `std::tuple`; use these instead of the `kamping/types/std/` headers when working with the full KaMPIng communicator

--- a/kamping-types/examples/type_traits_example.cpp
+++ b/kamping-types/examples/type_traits_example.cpp
@@ -23,19 +23,36 @@
 
 #include <mpi.h>
 
-#include "kamping/types/builtin_types.hpp"
-#include "kamping/types/contiguous_type.hpp"
 #include "kamping/types/mpi_type_traits.hpp"
 #include "kamping/types/scoped_datatype.hpp"
+#include "kamping/types/std/unsafe/trivially_copyable.hpp"
+#include "kamping/types/std/utility.hpp"
 #include "kamping/types/struct_type.hpp"
 
-// Teach kamping-types how to handle std::pair via struct_type.
-// When using full KaMPIng, include <kamping/types/utility.hpp> instead.
+// -----------------------------------------------------------------------
+// Manual mpi_type_traits specialization for a user-defined struct.
+//
+// Specialize mpi_type_traits in namespace kamping::types to register any
+// type that struct_type can reflect (std::pair, std::tuple, or a
+// Boost.PFR-reflectable aggregate when KAMPING_ENABLE_REFLECTION is set).
+// -----------------------------------------------------------------------
+struct Particle {
+    float  position[3]; ///< x, y, z
+    double mass;
+};
+
 namespace kamping::types {
-template <typename A, typename B>
-struct mpi_type_traits<std::pair<A, B>, std::enable_if_t<has_static_type_v<A> && has_static_type_v<B>>>
-    : struct_type<std::pair<A, B>> {};
+template <>
+struct mpi_type_traits<Particle> : struct_type<Particle> {};
 } // namespace kamping::types
+
+static_assert(kamping::types::has_static_type_v<Particle>);
+
+// A plain trivially-copyable struct — registered automatically by trivially_copyable.hpp.
+struct Point3D {
+    float x, y, z;
+};
+static_assert(kamping::types::has_static_type_v<Point3D>);
 
 int main(int argc, char** argv) {
     MPI_Init(&argc, &argv);

--- a/kamping-types/include/kamping/types/detail/contiguous_type_fwd.hpp
+++ b/kamping-types/include/kamping/types/detail/contiguous_type_fwd.hpp
@@ -13,6 +13,7 @@
 
 /// @file
 /// @brief Forward declarations for contiguous_type and byte_serialized to break include cycles.
+// IWYU pragma: private, include "kamping/types/contiguous_type.hpp"
 
 #pragma once
 #include <cstddef>

--- a/kamping-types/include/kamping/types/std/tuple.hpp
+++ b/kamping-types/include/kamping/types/std/tuple.hpp
@@ -1,0 +1,40 @@
+// This file is part of KaMPIng.
+//
+// Copyright 2024 The KaMPIng Authors
+//
+// KaMPIng is free software : you can redistribute it and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
+// version. KaMPIng is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+// implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+// for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along with KaMPIng.  If not, see
+// <https://www.gnu.org/licenses/>.
+//
+#pragma once
+
+#include <tuple>
+#include <type_traits>
+
+#include "kamping/types/mpi_type_traits.hpp"
+#include "kamping/types/struct_type.hpp"
+
+namespace kamping::types {
+
+/// @brief Specialization of \ref kamping::types::mpi_type_traits for `std::tuple`, representing
+///        the tuple as an MPI struct type derived from its element types.
+///
+/// All element types must already have a static MPI type (i.e. \ref kamping::types::has_static_type_v
+/// must be `true` for every element type). The resulting MPI datatype correctly reflects the memory
+/// layout, including any padding inserted by the compiler.
+///
+/// @note This header and \ref kamping/types/std/unsafe/tuple.hpp provide conflicting
+///       specializations — include only one.
+///
+/// @note For maximum throughput at the cost of correctness guarantees, use the byte-serialized
+///       variant in \ref kamping/types/std/unsafe/tuple.hpp instead.
+template <typename... Ts>
+struct mpi_type_traits<std::tuple<Ts...>, std::enable_if_t<(has_static_type_v<Ts> && ...)>>
+    : struct_type<std::tuple<Ts...>> {};
+
+} // namespace kamping::types

--- a/kamping-types/include/kamping/types/std/tuple.hpp
+++ b/kamping-types/include/kamping/types/std/tuple.hpp
@@ -21,6 +21,9 @@
 
 namespace kamping::types {
 
+/// @addtogroup kamping_types
+/// @{
+
 /// @brief Specialization of \ref kamping::types::mpi_type_traits for `std::tuple`, representing
 ///        the tuple as an MPI struct type derived from its element types.
 ///
@@ -36,5 +39,7 @@ namespace kamping::types {
 template <typename... Ts>
 struct mpi_type_traits<std::tuple<Ts...>, std::enable_if_t<(has_static_type_v<Ts> && ...)>>
     : struct_type<std::tuple<Ts...>> {};
+
+/// @}
 
 } // namespace kamping::types

--- a/kamping-types/include/kamping/types/std/unsafe/trivially_copyable.hpp
+++ b/kamping-types/include/kamping/types/std/unsafe/trivially_copyable.hpp
@@ -21,6 +21,9 @@
 
 namespace kamping::types {
 
+/// @addtogroup kamping_types
+/// @{
+
 /// @brief Opt-in catch-all specialization of \ref kamping::types::mpi_type_traits for any
 ///        trivially copyable type not already covered by the built-in dispatcher.
 ///
@@ -41,5 +44,7 @@ struct mpi_type_traits<
         std::is_trivially_copyable<T>::value && !has_auto_dispatched_type_v<T>
         && !kamping::internal::is_std_pair<T>::value && !kamping::internal::is_std_tuple<T>::value>>
     : byte_serialized<T> {};
+
+/// @}
 
 } // namespace kamping::types

--- a/kamping-types/include/kamping/types/std/unsafe/trivially_copyable.hpp
+++ b/kamping-types/include/kamping/types/std/unsafe/trivially_copyable.hpp
@@ -41,9 +41,9 @@ template <typename T>
 struct mpi_type_traits<
     T,
     std::enable_if_t<
-        std::is_trivially_copyable<T>::value && !has_auto_dispatched_type_v<T>
-        && !kamping::internal::is_std_pair<T>::value && !kamping::internal::is_std_tuple<T>::value>>
-    : byte_serialized<T> {};
+        std::is_trivially_copyable<T>::value
+        && !has_auto_dispatched_type_v<T> && !kamping::internal::is_std_pair<T>::value
+        && !kamping::internal::is_std_tuple<T>::value>> : byte_serialized<T> {};
 
 /// @}
 

--- a/kamping-types/include/kamping/types/std/unsafe/trivially_copyable.hpp
+++ b/kamping-types/include/kamping/types/std/unsafe/trivially_copyable.hpp
@@ -1,0 +1,45 @@
+// This file is part of KaMPIng.
+//
+// Copyright 2024 The KaMPIng Authors
+//
+// KaMPIng is free software : you can redistribute it and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
+// version. KaMPIng is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+// implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+// for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along with KaMPIng.  If not, see
+// <https://www.gnu.org/licenses/>.
+//
+#pragma once
+
+#include <type_traits>
+
+#include "kamping/types/contiguous_type.hpp"
+#include "kamping/types/detail/type_helpers.hpp"
+#include "kamping/types/mpi_type_traits.hpp"
+
+namespace kamping::types {
+
+/// @brief Opt-in catch-all specialization of \ref kamping::types::mpi_type_traits for any
+///        trivially copyable type not already covered by the built-in dispatcher.
+///
+/// Represents the object as a flat sequence of `sizeof(T)` bytes using `MPI_BYTE`.
+///
+/// `std::pair` and `std::tuple` are excluded so this header composes safely with
+/// \ref kamping/types/std/utility.hpp, \ref kamping/types/std/tuple.hpp, and their unsafe
+/// counterparts — include whichever combination suits your use case.
+///
+/// @warning Padding bytes between fields are silently included in the byte representation.
+///          This is correct for tightly-packed structs, but incorrect for structs with
+///          compiler-inserted padding holes. Users opt in to this trade-off knowingly by
+///          including this header.
+template <typename T>
+struct mpi_type_traits<
+    T,
+    std::enable_if_t<
+        std::is_trivially_copyable<T>::value && !has_auto_dispatched_type_v<T>
+        && !kamping::internal::is_std_pair<T>::value && !kamping::internal::is_std_tuple<T>::value>>
+    : byte_serialized<T> {};
+
+} // namespace kamping::types

--- a/kamping-types/include/kamping/types/std/unsafe/tuple.hpp
+++ b/kamping-types/include/kamping/types/std/unsafe/tuple.hpp
@@ -21,6 +21,9 @@
 
 namespace kamping::types {
 
+/// @addtogroup kamping_types
+/// @{
+
 /// @brief Specialization of \ref kamping::types::mpi_type_traits for `std::tuple`, representing
 ///        the tuple as a flat sequence of `sizeof(std::tuple<Ts...>)` bytes using `MPI_BYTE`.
 ///
@@ -36,5 +39,7 @@ namespace kamping::types {
 template <typename... Ts>
 struct mpi_type_traits<std::tuple<Ts...>, std::enable_if_t<(has_static_type_v<Ts> && ...)>>
     : byte_serialized<std::tuple<Ts...>> {};
+
+/// @}
 
 } // namespace kamping::types

--- a/kamping-types/include/kamping/types/std/unsafe/tuple.hpp
+++ b/kamping-types/include/kamping/types/std/unsafe/tuple.hpp
@@ -1,0 +1,40 @@
+// This file is part of KaMPIng.
+//
+// Copyright 2024 The KaMPIng Authors
+//
+// KaMPIng is free software : you can redistribute it and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
+// version. KaMPIng is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+// implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+// for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along with KaMPIng.  If not, see
+// <https://www.gnu.org/licenses/>.
+//
+#pragma once
+
+#include <tuple>
+#include <type_traits>
+
+#include "kamping/types/contiguous_type.hpp"
+#include "kamping/types/mpi_type_traits.hpp"
+
+namespace kamping::types {
+
+/// @brief Specialization of \ref kamping::types::mpi_type_traits for `std::tuple`, representing
+///        the tuple as a flat sequence of `sizeof(std::tuple<Ts...>)` bytes using `MPI_BYTE`.
+///
+/// All element types must already have a static MPI type (i.e. \ref kamping::types::has_static_type_v
+/// must be `true` for every element type).
+///
+/// @warning This serialization ignores any padding bytes the compiler may insert between or after
+///          elements. Sending a padded tuple is only correct when both sides share the same ABI.
+///          For a layout-safe alternative use \ref kamping/types/std/tuple.hpp.
+///
+/// @note This header and \ref kamping/types/std/tuple.hpp provide conflicting
+///       specializations — include only one.
+template <typename... Ts>
+struct mpi_type_traits<std::tuple<Ts...>, std::enable_if_t<(has_static_type_v<Ts> && ...)>>
+    : byte_serialized<std::tuple<Ts...>> {};
+
+} // namespace kamping::types

--- a/kamping-types/include/kamping/types/std/unsafe/utility.hpp
+++ b/kamping-types/include/kamping/types/std/unsafe/utility.hpp
@@ -1,0 +1,42 @@
+// This file is part of KaMPIng.
+//
+// Copyright 2024 The KaMPIng Authors
+//
+// KaMPIng is free software : you can redistribute it and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
+// version. KaMPIng is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+// implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+// for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along with KaMPIng.  If not, see
+// <https://www.gnu.org/licenses/>.
+//
+#pragma once
+
+#include <type_traits>
+#include <utility>
+
+#include "kamping/types/contiguous_type.hpp"
+#include "kamping/types/mpi_type_traits.hpp"
+
+namespace kamping::types {
+
+/// @brief Specialization of \ref kamping::types::mpi_type_traits for `std::pair`, representing
+///        the pair as a flat sequence of `sizeof(std::pair<First, Second>)` bytes using `MPI_BYTE`.
+///
+/// Both field types must already have a static MPI type (i.e. \ref kamping::types::has_static_type_v
+/// must be `true` for both `First` and `Second`).
+///
+/// @warning This serialization ignores any padding bytes the compiler may insert between or after
+///          fields. Sending a padded pair is only correct when both sides share the same ABI. For
+///          a layout-safe alternative use \ref kamping/types/std/utility.hpp.
+///
+/// @note This header and \ref kamping/types/std/utility.hpp provide conflicting
+///       specializations — include only one.
+template <typename First, typename Second>
+struct mpi_type_traits<
+    std::pair<First, Second>,
+    std::enable_if_t<has_static_type_v<First> && has_static_type_v<Second>>>
+    : byte_serialized<std::pair<First, Second>> {};
+
+} // namespace kamping::types

--- a/kamping-types/include/kamping/types/std/unsafe/utility.hpp
+++ b/kamping-types/include/kamping/types/std/unsafe/utility.hpp
@@ -21,6 +21,9 @@
 
 namespace kamping::types {
 
+/// @addtogroup kamping_types
+/// @{
+
 /// @brief Specialization of \ref kamping::types::mpi_type_traits for `std::pair`, representing
 ///        the pair as a flat sequence of `sizeof(std::pair<First, Second>)` bytes using `MPI_BYTE`.
 ///
@@ -38,5 +41,7 @@ struct mpi_type_traits<
     std::pair<First, Second>,
     std::enable_if_t<has_static_type_v<First> && has_static_type_v<Second>>>
     : byte_serialized<std::pair<First, Second>> {};
+
+/// @}
 
 } // namespace kamping::types

--- a/kamping-types/include/kamping/types/std/utility.hpp
+++ b/kamping-types/include/kamping/types/std/utility.hpp
@@ -39,8 +39,7 @@ namespace kamping::types {
 template <typename First, typename Second>
 struct mpi_type_traits<
     std::pair<First, Second>,
-    std::enable_if_t<has_static_type_v<First> && has_static_type_v<Second>>>
-    : struct_type<std::pair<First, Second>> {};
+    std::enable_if_t<has_static_type_v<First> && has_static_type_v<Second>>> : struct_type<std::pair<First, Second>> {};
 
 /// @}
 

--- a/kamping-types/include/kamping/types/std/utility.hpp
+++ b/kamping-types/include/kamping/types/std/utility.hpp
@@ -1,0 +1,42 @@
+// This file is part of KaMPIng.
+//
+// Copyright 2024 The KaMPIng Authors
+//
+// KaMPIng is free software : you can redistribute it and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
+// version. KaMPIng is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
+// implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+// for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License along with KaMPIng.  If not, see
+// <https://www.gnu.org/licenses/>.
+//
+#pragma once
+
+#include <type_traits>
+#include <utility>
+
+#include "kamping/types/mpi_type_traits.hpp"
+#include "kamping/types/struct_type.hpp"
+
+namespace kamping::types {
+
+/// @brief Specialization of \ref kamping::types::mpi_type_traits for `std::pair`, representing
+///        the pair as an MPI struct type derived from its field types.
+///
+/// Both field types must already have a static MPI type (i.e. \ref kamping::types::has_static_type_v
+/// must be `true` for both `First` and `Second`). The resulting MPI datatype correctly reflects
+/// the memory layout, including any padding inserted by the compiler.
+///
+/// @note This header and \ref kamping/types/std/unsafe/utility.hpp provide conflicting
+///       specializations — include only one.
+///
+/// @note For maximum throughput at the cost of correctness guarantees, use the byte-serialized
+///       variant in \ref kamping/types/std/unsafe/utility.hpp instead.
+template <typename First, typename Second>
+struct mpi_type_traits<
+    std::pair<First, Second>,
+    std::enable_if_t<has_static_type_v<First> && has_static_type_v<Second>>>
+    : struct_type<std::pair<First, Second>> {};
+
+} // namespace kamping::types

--- a/kamping-types/include/kamping/types/std/utility.hpp
+++ b/kamping-types/include/kamping/types/std/utility.hpp
@@ -21,6 +21,9 @@
 
 namespace kamping::types {
 
+/// @addtogroup kamping_types
+/// @{
+
 /// @brief Specialization of \ref kamping::types::mpi_type_traits for `std::pair`, representing
 ///        the pair as an MPI struct type derived from its field types.
 ///
@@ -38,5 +41,7 @@ struct mpi_type_traits<
     std::pair<First, Second>,
     std::enable_if_t<has_static_type_v<First> && has_static_type_v<Second>>>
     : struct_type<std::pair<First, Second>> {};
+
+/// @}
 
 } // namespace kamping::types


### PR DESCRIPTION
## Summary

- Adds opt-in `mpi_type_traits` specializations for `std::pair` and `std::tuple` to the standalone `kamping-types` module under a new `kamping/types/std/` hierarchy
- Adds an opt-in catch-all for any trivially copyable type
- Updates the `type_traits_example` to use the new headers alongside a manual specialization example

## New headers

| Header | What it provides |
|--------|-----------------|
| `kamping/types/std/utility.hpp` | `std::pair<F,S>` via `struct_type` — safe, layout-aware |
| `kamping/types/std/tuple.hpp` | `std::tuple<Ts...>` via `struct_type` — safe, layout-aware |
| `kamping/types/std/unsafe/utility.hpp` | `std::pair<F,S>` via `byte_serialized` |
| `kamping/types/std/unsafe/tuple.hpp` | `std::tuple<Ts...>` via `byte_serialized` |
| `kamping/types/std/unsafe/trivially_copyable.hpp` | catch-all for any trivially copyable type via `byte_serialized`; excludes `std::pair`/`std::tuple` so it composes with the above |

The safe and unsafe variants for pair/tuple share the same `enable_if` condition and are mutually exclusive — include only one per type. All headers are C++17.

## Test plan

- [x] `example_type_traits` builds and demonstrates `std/utility.hpp`, `std/unsafe/trivially_copyable.hpp`, and a manual `mpi_type_traits` specialization side by side

🤖 Generated with [Claude Code](https://claude.com/claude-code)