### PR TITLE
kamping-types: Fix warning about missing return statement.

### DIFF
--- a/kamping-types/include/kamping/types/builtin_types.hpp
+++ b/kamping-types/include/kamping/types/builtin_types.hpp
@@ -45,6 +45,7 @@ constexpr bool category_has_to_be_committed(TypeCategory category) {
         case TypeCategory::contiguous:
             return true;
     }
+    return true;
 }
 
 /// @brief Checks if the type \p T is a builtin MPI type.


### PR DESCRIPTION
This pull request makes a small change to the `category_has_to_be_committed` function in `kamping-types/include/kamping/types/builtin_types.hpp`, ensuring that the function always returns a value regardless of the input. This prevents potential undefined behavior if an unhandled `TypeCategory` is passed in.