### PR TITLE
fix(cmake): Avoid redefining kamping::types target

### DIFF
--- a/kamping-types/CMakeLists.txt
+++ b/kamping-types/CMakeLists.txt
@@ -2,8 +2,8 @@ cmake_minimum_required(VERSION 3.25)
 project(kamping-types LANGUAGES CXX)
 
 if (TARGET kamping::types)
-  return()
-endif()
+    return()
+endif ()
 
 add_library(kamping_types INTERFACE)
 target_include_directories(kamping_types INTERFACE include)

--- a/kamping-types/CMakeLists.txt
+++ b/kamping-types/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.25)
 project(kamping-types LANGUAGES CXX)
 
+if (TARGET kamping::types)
+  return()
+endif()
+
 add_library(kamping_types INTERFACE)
 target_include_directories(kamping_types INTERFACE include)
 target_compile_features(kamping_types INTERFACE cxx_std_17)


### PR DESCRIPTION
Add early return in kamping-types/CMakeLists.txt if target exists to prevent duplicate target definition errors when including KaMPIng-v1 alongside KaMPIng v2.

This closes #804