### PR TITLE
[kamping-types] Free immediate type constructed during `struct_type` creation.

### DIFF
--- a/kamping-types/include/kamping/types/struct_type.hpp
+++ b/kamping-types/include/kamping/types/struct_type.hpp
@@ -154,6 +154,7 @@ MPI_Datatype struct_type<T, Lookup>::data_type() {
     KAMPING_ASSERT(err == MPI_SUCCESS, "MPI_Type_create_struct failed");
     MPI_Datatype resized_type;
     err = MPI_Type_create_resized(type, 0, sizeof(T), &resized_type);
+    MPI_Type_free(&type);
     KAMPING_ASSERT(err == MPI_SUCCESS, "MPI_Type_create_resized failed");
     return resized_type;
 }


### PR DESCRIPTION
The code in `struct_type.hpp` now explicitly frees the temporary MPI datatype after resizing, which prevents potential memory/resource leaks. MPI allows freeing the type after it has been passed to another type constructor.